### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
-    <groupId>com.github</groupId>
+    <groupId>io.9tiger</groupId>
     <artifactId>db2rest-parent</artifactId>
     <version>1.2.4-SNAPSHOT</version>
     <packaging>pom</packaging>


### PR DESCRIPTION
Fixes #630 
- updates to newly registered namespace coordinate on Sonatype's Maven Central `io.9tiger`
- basically the groupId is the reverse of our official domain name `9tiger.io` we have registered already on Cloudflare.