### PR TITLE
Update new groupId `io.9tiger` in POMs

### DIFF
--- a/api-rest/pom-oracle9i.xml
+++ b/api-rest/pom-oracle9i.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.github</groupId>
+        <groupId>io.9tiger</groupId>
         <artifactId>db2rest-parent</artifactId>
         <version>1.2.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
@@ -33,51 +33,51 @@
 
 
         <dependency>
-            <groupId>com.github</groupId>
+            <groupId>io.9tiger</groupId>
             <artifactId>auth</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
 
 
         <dependency>
-            <groupId>com.github</groupId>
+            <groupId>io.9tiger</groupId>
             <artifactId>rest-common</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>com.github</groupId>
+            <groupId>io.9tiger</groupId>
             <artifactId>mongo-support</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>com.github</groupId>
+            <groupId>io.9tiger</groupId>
             <artifactId>rdbms-support</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
 
         <!--TODO - Remove -->
         <dependency>
-            <groupId>com.github</groupId>
+            <groupId>io.9tiger</groupId>
             <artifactId>pg-dialect</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>com.github</groupId>
+            <groupId>io.9tiger</groupId>
             <artifactId>mysql-dialect</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>com.github</groupId>
+            <groupId>io.9tiger</groupId>
             <artifactId>mariadb-dialect</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>com.github</groupId>
+            <groupId>io.9tiger</groupId>
             <artifactId>oracle9i-dialect</artifactId>
             <version>${project.parent.version}</version>
         </dependency>

--- a/api-rest/pom.xml
+++ b/api-rest/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.github</groupId>
+        <groupId>io.9tiger</groupId>
         <artifactId>db2rest-parent</artifactId>
         <version>1.2.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
@@ -28,62 +28,62 @@
 
 
         <dependency>
-            <groupId>com.github</groupId>
+            <groupId>io.9tiger</groupId>
             <artifactId>auth</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
 
 
         <dependency>
-            <groupId>com.github</groupId>
+            <groupId>io.9tiger</groupId>
             <artifactId>db2rest-common</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
 
 
         <dependency>
-            <groupId>com.github</groupId>
+            <groupId>io.9tiger</groupId>
             <artifactId>rest-common</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>com.github</groupId>
+            <groupId>io.9tiger</groupId>
             <artifactId>mongo-support</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>com.github</groupId>
+            <groupId>io.9tiger</groupId>
             <artifactId>rdbms-support</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>com.github</groupId>
+            <groupId>io.9tiger</groupId>
             <artifactId>pg-dialect</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>com.github</groupId>
+            <groupId>io.9tiger</groupId>
             <artifactId>mysql-dialect</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>com.github</groupId>
+            <groupId>io.9tiger</groupId>
             <artifactId>mariadb-dialect</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>com.github</groupId>
+            <groupId>io.9tiger</groupId>
             <artifactId>oracle-dialect</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.github</groupId>
+            <groupId>io.9tiger</groupId>
             <artifactId>mssql-dialect</artifactId>
             <version>${project.parent.version}</version>
         </dependency>

--- a/auth/pom.xml
+++ b/auth/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.github</groupId>
+        <groupId>io.9tiger</groupId>
         <artifactId>db2rest-parent</artifactId>
         <version>1.2.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>

--- a/db2rest-common/pom.xml
+++ b/db2rest-common/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.github</groupId>
+        <groupId>io.9tiger</groupId>
         <artifactId>db2rest-parent</artifactId>
         <version>1.2.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>

--- a/mariadb-dialect/pom.xml
+++ b/mariadb-dialect/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.github</groupId>
+        <groupId>io.9tiger</groupId>
         <artifactId>db2rest-parent</artifactId>
         <version>1.2.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
@@ -22,7 +22,7 @@
         </dependency>
 
         <dependency>
-            <groupId>com.github</groupId>
+            <groupId>io.9tiger</groupId>
             <artifactId>rdbms-common</artifactId>
             <version>${project.parent.version}</version>
         </dependency>

--- a/mongo-support/pom.xml
+++ b/mongo-support/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.github</groupId>
+        <groupId>io.9tiger</groupId>
         <artifactId>db2rest-parent</artifactId>
         <version>1.2.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
@@ -23,7 +23,7 @@
         </dependency>
 
         <dependency>
-            <groupId>com.github</groupId>
+            <groupId>io.9tiger</groupId>
             <artifactId>db2rest-common</artifactId>
             <version>${project.parent.version}</version>
         </dependency>

--- a/mssql-dialect/pom.xml
+++ b/mssql-dialect/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.github</groupId>
+        <groupId>io.9tiger</groupId>
         <artifactId>db2rest-parent</artifactId>
         <version>1.2.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
@@ -21,7 +21,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.github</groupId>
+            <groupId>io.9tiger</groupId>
             <artifactId>rdbms-common</artifactId>
             <version>${project.parent.version}</version>
         </dependency>

--- a/mysql-dialect/pom.xml
+++ b/mysql-dialect/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.github</groupId>
+        <groupId>io.9tiger</groupId>
         <artifactId>db2rest-parent</artifactId>
         <version>1.2.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
@@ -21,7 +21,7 @@
         </dependency>
 
         <dependency>
-            <groupId>com.github</groupId>
+            <groupId>io.9tiger</groupId>
             <artifactId>rdbms-common</artifactId>
             <version>${project.parent.version}</version>
         </dependency>

--- a/oracle-dialect/pom.xml
+++ b/oracle-dialect/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.github</groupId>
+        <groupId>io.9tiger</groupId>
         <artifactId>db2rest-parent</artifactId>
         <version>1.2.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
@@ -23,7 +23,7 @@
 
 
         <dependency>
-            <groupId>com.github</groupId>
+            <groupId>io.9tiger</groupId>
             <artifactId>rdbms-common</artifactId>
             <version>${project.parent.version}</version>
         </dependency>

--- a/oracle9i-dialect/pom.xml
+++ b/oracle9i-dialect/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.github</groupId>
+        <groupId>io.9tiger</groupId>
         <artifactId>db2rest-parent</artifactId>
         <version>1.2.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
@@ -23,7 +23,7 @@
 
 
         <dependency>
-            <groupId>com.github</groupId>
+            <groupId>io.9tiger</groupId>
             <artifactId>rdbms-common</artifactId>
             <version>${project.parent.version}</version>
         </dependency>

--- a/pg-dialect/pom.xml
+++ b/pg-dialect/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.github</groupId>
+        <groupId>io.9tiger</groupId>
         <artifactId>db2rest-parent</artifactId>
         <version>1.2.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
@@ -28,7 +28,7 @@
         </dependency>
 
         <dependency>
-            <groupId>com.github</groupId>
+            <groupId>io.9tiger</groupId>
             <artifactId>rdbms-common</artifactId>
             <version>${project.parent.version}</version>
         </dependency>

--- a/rdbms-common/pom.xml
+++ b/rdbms-common/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.github</groupId>
+        <groupId>io.9tiger</groupId>
         <artifactId>db2rest-parent</artifactId>
         <version>1.2.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
@@ -17,7 +17,7 @@
     <dependencies>
 
         <dependency>
-            <groupId>com.github</groupId>
+            <groupId>io.9tiger</groupId>
             <artifactId>db2rest-common</artifactId>
             <version>${project.parent.version}</version>
         </dependency>

--- a/rdbms-spring-boot-starter/pom.xml
+++ b/rdbms-spring-boot-starter/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.github</groupId>
+        <groupId>io.9tiger</groupId>
         <artifactId>db2rest-parent</artifactId>
         <version>1.2.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
@@ -17,31 +17,31 @@
     <dependencies>
 
         <dependency>
-            <groupId>com.github</groupId>
+            <groupId>io.9tiger</groupId>
             <artifactId>rdbms-support</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>com.github</groupId>
+            <groupId>io.9tiger</groupId>
             <artifactId>oracle-dialect</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>com.github</groupId>
+            <groupId>io.9tiger</groupId>
             <artifactId>pg-dialect</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>com.github</groupId>
+            <groupId>io.9tiger</groupId>
             <artifactId>mysql-dialect</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>com.github</groupId>
+            <groupId>io.9tiger</groupId>
             <artifactId>mariadb-dialect</artifactId>
             <version>${project.parent.version}</version>
         </dependency>

--- a/rdbms-support/pom.xml
+++ b/rdbms-support/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.github</groupId>
+        <groupId>io.9tiger</groupId>
         <artifactId>db2rest-parent</artifactId>
         <version>1.2.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
@@ -28,13 +28,13 @@
         </dependency>
 
         <dependency>
-            <groupId>com.github</groupId>
+            <groupId>io.9tiger</groupId>
             <artifactId>db2rest-common</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>com.github</groupId>
+            <groupId>io.9tiger</groupId>
             <artifactId>rdbms-common</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
@@ -50,7 +50,7 @@
             <version>1.1.0</version>
         </dependency>
         <dependency>
-            <groupId>com.github</groupId>
+            <groupId>io.9tiger</groupId>
             <artifactId>rest-common</artifactId>
             <version>${project.parent.version}</version>
             <scope>compile</scope>

--- a/rest-common/pom.xml
+++ b/rest-common/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.github</groupId>
+        <groupId>io.9tiger</groupId>
         <artifactId>db2rest-parent</artifactId>
         <version>1.2.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
@@ -18,7 +18,7 @@
     <dependencies>
 
         <dependency>
-            <groupId>com.github</groupId>
+            <groupId>io.9tiger</groupId>
             <artifactId>db2rest-common</artifactId>
             <version>${project.parent.version}</version>
         </dependency>


### PR DESCRIPTION
- since we have registered a new namespace within Sonatype's Central, we need to update all the POM's as well, for proper packaging.