### PR TITLE
temporarily adding error stack tracing with -e

### DIFF
--- a/.github/workflows/maven-central-publish.yml
+++ b/.github/workflows/maven-central-publish.yml
@@ -25,7 +25,7 @@ jobs:
         cache: 'maven'
 
     - name: Publish package
-      run: mvn -B deploy -P release -DskipTests
+      run: mvn -e -B deploy -P release -DskipTests
       env:
         MAVEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
         MAVEN_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
@@ -33,7 +33,7 @@ jobs:
         MAVEN_GPG_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
 
     - name: Publish package Oracle9i
-      run: mvn -B deploy -P release --file api-rest/pom-oracle9i.xml -DskipTests
+      run: mvn -e -B deploy -P release --file api-rest/pom-oracle9i.xml -DskipTests
       env:
         MAVEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
         MAVEN_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}

--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,6 @@
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
-                                <phase>verify</phase>
                                 <goals>
                                     <goal>sign</goal>
                                 </goals>


### PR DESCRIPTION
- the problem is the MAVEN_GPG_KEY is not parsed or getting injected correct?  error during Action run https://github.com/9tigerio/db2rest/actions/runs/11639045655/job/32415185526#step:4:825

  ```
  Error:  Failed to execute goal org.apache.maven.plugins:maven-gpg-plugin:3.2.7:sign
    (sign-artifacts) on project db2rest-parent: Key ring material not found -> [Help 1]
  ```
  Found out in maven-gpg-plugin source code that "key material" actually means `MAVEN_GPG_KEY`.  Thanks source!

- verify is the default, so can remove