### PR TITLE
fix version string on oracle9i POM

### DIFF
--- a/api-rest/pom-oracle9i.xml
+++ b/api-rest/pom-oracle9i.xml
@@ -12,7 +12,7 @@
     </parent>
 
     <artifactId>db2rest-oracle9i</artifactId>
-    <version>${project.parent.version}</version>
+    <version>1.2.4</version>
     <packaging>jar</packaging>
     <name>db2rest-oracle9i</name>
     <description>db2rest-oracle9i</description>


### PR DESCRIPTION
- needs to be a constant, NOT an expression like ${project.parent.version}