### PR TITLE
Add column information to database schema endpoint

### DIFF
--- a/api-rest/src/main/java/com/homihq/db2rest/jdbc/rest/meta/schema/ColumnObject.java
+++ b/api-rest/src/main/java/com/homihq/db2rest/jdbc/rest/meta/schema/ColumnObject.java
@@ -2,7 +2,7 @@ package com.homihq.db2rest.jdbc.rest.meta.schema;
 
 import com.homihq.db2rest.jdbc.config.model.DbColumn;
 
-public record ColumnObject(String name, Boolean pk, String columnDataTypeName) {
+public record ColumnObject(String name, Boolean pk, String dataType) {
     public ColumnObject(DbColumn dbColumn) {
         this(
                 dbColumn.name(),

--- a/api-rest/src/main/java/com/homihq/db2rest/jdbc/rest/meta/schema/ColumnObject.java
+++ b/api-rest/src/main/java/com/homihq/db2rest/jdbc/rest/meta/schema/ColumnObject.java
@@ -1,0 +1,14 @@
+package com.homihq.db2rest.jdbc.rest.meta.schema;
+
+import com.homihq.db2rest.jdbc.config.model.DbColumn;
+
+public record ColumnObject(String schema, Boolean pk, String columnDataTypeName) {
+    public ColumnObject(DbColumn dbColumn) {
+        this(
+                dbColumn.name(),
+                dbColumn.pk(),
+                dbColumn.columnDataTypeName()
+        );
+    }
+}
+

--- a/api-rest/src/main/java/com/homihq/db2rest/jdbc/rest/meta/schema/ColumnObject.java
+++ b/api-rest/src/main/java/com/homihq/db2rest/jdbc/rest/meta/schema/ColumnObject.java
@@ -2,7 +2,7 @@ package com.homihq.db2rest.jdbc.rest.meta.schema;
 
 import com.homihq.db2rest.jdbc.config.model.DbColumn;
 
-public record ColumnObject(String schema, Boolean pk, String columnDataTypeName) {
+public record ColumnObject(String name, Boolean pk, String columnDataTypeName) {
     public ColumnObject(DbColumn dbColumn) {
         this(
                 dbColumn.name(),

--- a/api-rest/src/main/java/com/homihq/db2rest/jdbc/rest/meta/schema/SchemaController.java
+++ b/api-rest/src/main/java/com/homihq/db2rest/jdbc/rest/meta/schema/SchemaController.java
@@ -43,9 +43,7 @@ public class SchemaController implements SchemaRestApi{
         SchemaFilter schemaFilter = getSchemaFilter(filter);
 
         if(Objects.isNull(schemaFilter)) {
-
-            return dbTables.stream()
-                    .map(t -> new TableObject(t.schema(), t.name(), t.type())).toList();
+            return dbTables.stream().map(TableObject::new).toList();
         }
         else{
             log.info("schemaFilter - {}", schemaFilter);
@@ -64,7 +62,7 @@ public class SchemaController implements SchemaRestApi{
                                    && StringUtils.containsIgnoreCase(dbTable.type(), schemaFilter.value);
 
                     })
-                    .map(t -> new TableObject(t.schema(), t.name(), t.type())).toList();
+                    .map(TableObject::new).toList();
         }
 
     }

--- a/api-rest/src/main/java/com/homihq/db2rest/jdbc/rest/meta/schema/SchemaController.java
+++ b/api-rest/src/main/java/com/homihq/db2rest/jdbc/rest/meta/schema/SchemaController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Function;
 
 /**
  * provides methods to filter and retrieve schema objects from a database
@@ -25,10 +26,11 @@ public class SchemaController implements SchemaRestApi{
     /** 
      * @param dbId database id from which to retrieve the schema objects
      * @param filter filter conditions to match against a schema, name, or type
+     * @param columns include the column information for a table
      * @return list of schema objects (schema, name, type) that match the filter conditions
      */
     @Override
-    public List<TableObject> getObjects(String dbId, String filter) {
+    public List<? extends TableObject> getObjects(String dbId, String filter, Boolean columns) {
 
         log.info("Filter - {}", filter);
 
@@ -38,12 +40,13 @@ public class SchemaController implements SchemaRestApi{
 
         if(Objects.isNull(dbMeta)) return List.of();
 
-        List<DbTable> dbTables = dbMeta.dbTables();
-
         SchemaFilter schemaFilter = getSchemaFilter(filter);
 
+        List<DbTable> dbTables = dbMeta.dbTables();
+        Function<DbTable, ? extends TableObject> tableMapper = columns ? TableWithColumnsObject::new : TableObject::new;
+
         if(Objects.isNull(schemaFilter)) {
-            return dbTables.stream().map(TableObject::new).toList();
+            return dbTables.stream().map(tableMapper).toList();
         }
         else{
             log.info("schemaFilter - {}", schemaFilter);
@@ -62,7 +65,7 @@ public class SchemaController implements SchemaRestApi{
                                    && StringUtils.containsIgnoreCase(dbTable.type(), schemaFilter.value);
 
                     })
-                    .map(TableObject::new).toList();
+                    .map(tableMapper).toList();
         }
 
     }

--- a/api-rest/src/main/java/com/homihq/db2rest/jdbc/rest/meta/schema/SchemaRestApi.java
+++ b/api-rest/src/main/java/com/homihq/db2rest/jdbc/rest/meta/schema/SchemaRestApi.java
@@ -1,6 +1,10 @@
 package com.homihq.db2rest.jdbc.rest.meta.schema;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.*;
 
@@ -9,15 +13,25 @@ import static com.homihq.db2rest.jdbc.rest.RdbmsRestApi.VERSION;
 @RequestMapping(VERSION + "/{dbId}/$schemas")
 @Tag(name = "Schema Objects", description = "Details about schemas and tables")
 public interface SchemaRestApi {
-
-
-    @Operation(summary = "Get all database objects for a given dbId",
-            description = "Get all database objects from all schemas/catalogs, tables, columns", tags = { "Schema Objects" })
+    @Operation(
+            summary = "Get all database objects for a given dbId",
+            description = "Get all database objects from all schemas/catalogs, tables, columns",
+            tags = { "Schema Objects" }
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Successful operation",
+                    content = {
+                            @Content(mediaType = "application/json",
+                            schema = @Schema(oneOf = {TableObject.class, TableWithColumnsObject.class}))
+                    }
+             )
+     })
     @GetMapping()
-    List<TableObject> getObjects(
+    List<? extends TableObject> getObjects(
             @PathVariable String dbId,
-            @RequestParam(name = "filter", required = false, defaultValue = "") String filter);
-
-
-
+            @RequestParam(name = "filter", required = false, defaultValue = "") String filter,
+            @RequestParam(name = "columns", required = false, defaultValue = "false") Boolean columns
+    );
 }

--- a/api-rest/src/main/java/com/homihq/db2rest/jdbc/rest/meta/schema/TableObject.java
+++ b/api-rest/src/main/java/com/homihq/db2rest/jdbc/rest/meta/schema/TableObject.java
@@ -2,7 +2,9 @@ package com.homihq.db2rest.jdbc.rest.meta.schema;
 
 import com.homihq.db2rest.jdbc.config.model.DbTable;
 import lombok.Getter;
+import lombok.EqualsAndHashCode;
 
+@EqualsAndHashCode
 @Getter
 public class TableObject {
     private final String schema;

--- a/api-rest/src/main/java/com/homihq/db2rest/jdbc/rest/meta/schema/TableObject.java
+++ b/api-rest/src/main/java/com/homihq/db2rest/jdbc/rest/meta/schema/TableObject.java
@@ -1,4 +1,16 @@
 package com.homihq.db2rest.jdbc.rest.meta.schema;
 
-public record TableObject(String schema, String name, String type) {
+import com.homihq.db2rest.jdbc.config.model.DbTable;
+
+import java.util.List;
+
+public record TableObject(String schema, String name, String type, List<ColumnObject> columns) {
+    public TableObject(DbTable dbTable) {
+        this(
+                dbTable.schema(),
+                dbTable.name(),
+                dbTable.type(),
+                dbTable.dbColumns().stream().map(ColumnObject::new).toList()
+        );
+    };
 }

--- a/api-rest/src/main/java/com/homihq/db2rest/jdbc/rest/meta/schema/TableObject.java
+++ b/api-rest/src/main/java/com/homihq/db2rest/jdbc/rest/meta/schema/TableObject.java
@@ -1,16 +1,17 @@
 package com.homihq.db2rest.jdbc.rest.meta.schema;
 
 import com.homihq.db2rest.jdbc.config.model.DbTable;
+import lombok.Getter;
 
-import java.util.List;
+@Getter
+public class TableObject {
+    private final String schema;
+    private final String name;
+    private final String type;
 
-public record TableObject(String schema, String name, String type, List<ColumnObject> columns) {
     public TableObject(DbTable dbTable) {
-        this(
-                dbTable.schema(),
-                dbTable.name(),
-                dbTable.type(),
-                dbTable.dbColumns().stream().map(ColumnObject::new).toList()
-        );
+        this.schema = dbTable.schema();
+        this.name = dbTable.name();
+        this.type = dbTable.type();
     };
 }

--- a/api-rest/src/main/java/com/homihq/db2rest/jdbc/rest/meta/schema/TableWithColumnsObject.java
+++ b/api-rest/src/main/java/com/homihq/db2rest/jdbc/rest/meta/schema/TableWithColumnsObject.java
@@ -1,10 +1,12 @@
 package com.homihq.db2rest.jdbc.rest.meta.schema;
 
 import com.homihq.db2rest.jdbc.config.model.DbTable;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 import java.util.List;
 
+@EqualsAndHashCode(callSuper = true)
 @Getter
 public class TableWithColumnsObject extends TableObject {
     private final List<ColumnObject> columns;

--- a/api-rest/src/main/java/com/homihq/db2rest/jdbc/rest/meta/schema/TableWithColumnsObject.java
+++ b/api-rest/src/main/java/com/homihq/db2rest/jdbc/rest/meta/schema/TableWithColumnsObject.java
@@ -1,0 +1,16 @@
+package com.homihq.db2rest.jdbc.rest.meta.schema;
+
+import com.homihq.db2rest.jdbc.config.model.DbTable;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class TableWithColumnsObject extends TableObject {
+    private final List<ColumnObject> columns;
+
+    public TableWithColumnsObject(DbTable dbTable) {
+        super(dbTable);
+        this.columns = dbTable.dbColumns().stream().map(ColumnObject::new).toList();
+    }
+}

--- a/api-rest/src/test/java/com/homihq/db2rest/jdbc/rest/meta/schema/SchemaControllerIntegrationTest.java
+++ b/api-rest/src/test/java/com/homihq/db2rest/jdbc/rest/meta/schema/SchemaControllerIntegrationTest.java
@@ -67,7 +67,8 @@ class SchemaControllerIntegrationTest extends BaseIntegrationTest {
                 .andExpect(jsonPath("$.*").isArray())
                 //.andExpect(jsonPath("$.*", hasSize(4)))
                 .andExpect(jsonPath("$.*", anyOf(hasSize(1))))
-                .andExpect(jsonPath("$[0].*", hasSize(3)))
+                .andExpect(jsonPath("$[0].*", hasSize(4)))
+                .andExpect(jsonPath("$[0].columns.*", hasSize(1)))
                 .andDo(document("schema-no-filter"));
     }
 

--- a/api-rest/src/test/java/com/homihq/db2rest/jdbc/rest/meta/schema/SchemaControllerIntegrationTest.java
+++ b/api-rest/src/test/java/com/homihq/db2rest/jdbc/rest/meta/schema/SchemaControllerIntegrationTest.java
@@ -67,8 +67,30 @@ class SchemaControllerIntegrationTest extends BaseIntegrationTest {
                 .andExpect(jsonPath("$.*").isArray())
                 //.andExpect(jsonPath("$.*", hasSize(4)))
                 .andExpect(jsonPath("$.*", anyOf(hasSize(1))))
+                .andExpect(jsonPath("$[0].*", hasSize(3)))
+                .andDo(document("schema-no-filter"));
+    }
+
+    /**
+     * This test tests the use case where we request for schema's columns
+     * @throws Exception
+     */
+    @Test
+    void testGetColumnObjects() throws Exception {
+        mockMvc.perform(get(VERSION + "/1/$schemas")
+                        .param("columns", "true")
+                        .contentType(APPLICATION_JSON).accept(APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.*").isArray())
+                //.andExpect(jsonPath("$.*", hasSize(4)))
+                .andExpect(jsonPath("$.*", anyOf(hasSize(1))))
                 .andExpect(jsonPath("$[0].*", hasSize(4)))
                 .andExpect(jsonPath("$[0].columns.*", hasSize(1)))
+                .andExpect(jsonPath("$[0].columns[0].*", hasSize(3)))
+                .andExpect(jsonPath("$[0].columns[0].name").value("name"))
+                .andExpect(jsonPath("$[0].columns[0].pk").value(true))
+                .andExpect(jsonPath("$[0].columns[0].dataType").value("columnDataType"))
                 .andDo(document("schema-no-filter"));
     }
 

--- a/api-rest/src/test/java/com/homihq/db2rest/jdbc/rest/meta/schema/SchemaControllerTest.java
+++ b/api-rest/src/test/java/com/homihq/db2rest/jdbc/rest/meta/schema/SchemaControllerTest.java
@@ -43,7 +43,7 @@ class SchemaControllerTest {
     void getObjectsNoFilter() {
         when(jdbcManager.getDbMetaByDbId("key")).thenReturn(metadataMap.get("key"));
         List<TableObject> actualTableObject = schemaController.getObjects("key",null);
-        List<TableObject> expectedTableObject = metadataMap.get("key").dbTables().stream().map(t-> new TableObject(t.schema(),t.name(),t.type())).toList();
+        List<TableObject> expectedTableObject = metadataMap.get("key").dbTables().stream().map(TableObject::new).toList();
         schemaController.getObjects("key",null);
         assertEquals(expectedTableObject,actualTableObject);
     }
@@ -56,7 +56,7 @@ class SchemaControllerTest {
     @Test
     void testGetObjectsValidFilter_schema(){
         when(jdbcManager.getDbMetaByDbId("key")).thenReturn(metadataMap.get("key"));
-        List<TableObject> expectedTableObject = metadataMap.get("key").dbTables().stream().map(t-> new TableObject(t.schema(),t.name(),t.type())).toList();
+        List<TableObject> expectedTableObject = metadataMap.get("key").dbTables().stream().map(TableObject::new).toList();
         List<TableObject> actualTableObject = schemaController.getObjects("key","schema==schema");
         assertEquals(expectedTableObject,actualTableObject);
 
@@ -67,7 +67,7 @@ class SchemaControllerTest {
     @Test
     void testGetObjectsValidFilter_name() {
         when(jdbcManager.getDbMetaByDbId("key")).thenReturn(metadataMap.get("key"));
-        List<TableObject> expectedTableObject = metadataMap.get("key").dbTables().stream().map(t-> new TableObject(t.schema(),t.name(),t.type())).toList();
+        List<TableObject> expectedTableObject = metadataMap.get("key").dbTables().stream().map(TableObject::new).toList();
         List<TableObject> actualTableObject = schemaController.getObjects("key","name==name");
         assertEquals(expectedTableObject,actualTableObject);
 
@@ -77,7 +77,7 @@ class SchemaControllerTest {
     @Test
     void testGetObjectsValidFilter_type() {
         when(jdbcManager.getDbMetaByDbId("key")).thenReturn(metadataMap.get("key"));
-        List<TableObject> expectedTableObject = metadataMap.get("key").dbTables().stream().map(t-> new TableObject(t.schema(),t.name(),t.type())).toList();
+        List<TableObject> expectedTableObject = metadataMap.get("key").dbTables().stream().map(TableObject::new).toList();
         List<TableObject> actualTableObject = schemaController.getObjects("key","type==type");
         assertEquals(expectedTableObject,actualTableObject);
 

--- a/api-rest/src/test/java/com/homihq/db2rest/jdbc/rest/meta/schema/SchemaControllerTest.java
+++ b/api-rest/src/test/java/com/homihq/db2rest/jdbc/rest/meta/schema/SchemaControllerTest.java
@@ -39,62 +39,62 @@ class SchemaControllerTest {
         schemaController = new SchemaController(jdbcManager);
     }
 
+    private List<TableObject> getActualTableObject(String filter) {
+        List<TableObject> actualTableObject = (List<TableObject>) schemaController.getObjects("key",filter, Boolean.FALSE);
+        return actualTableObject;
+    };
+
+    private void testFilter(String goodFilter, String badFilter) {
+        when(jdbcManager.getDbMetaByDbId("key")).thenReturn(metadataMap.get("key"));
+        List<TableObject> expectedTableObject = metadataMap.get("key").dbTables().stream().map(TableObject::new).toList();
+        List<TableObject> actualTableObject = getActualTableObject(goodFilter);
+        assertEquals(expectedTableObject, actualTableObject);
+
+        actualTableObject = getActualTableObject(badFilter);
+        assertEquals(0,actualTableObject.size());
+    }
+
     @Test
     void getObjectsNoFilter() {
         when(jdbcManager.getDbMetaByDbId("key")).thenReturn(metadataMap.get("key"));
-        List<TableObject> actualTableObject = schemaController.getObjects("key",null);
+        List<TableObject> actualTableObject = getActualTableObject(null);
         List<TableObject> expectedTableObject = metadataMap.get("key").dbTables().stream().map(TableObject::new).toList();
-        schemaController.getObjects("key",null);
         assertEquals(expectedTableObject,actualTableObject);
     }
     @Test
     void testGetObjectsFilterInvalid() {
         when(jdbcManager.getDbMetaByDbId("key")).thenReturn(metadataMap.get("key"));
-        Throwable exception = assertThrows(GenericDataAccessException.class,() -> schemaController.getObjects("key","invalidFilter"));
+        Throwable exception = assertThrows(GenericDataAccessException.class,() -> schemaController.getObjects("key","invalidFilter", Boolean.FALSE));
         assertEquals("Invalid filter condition. Only == supported for schema filter using a single value only.",exception.getMessage());
     }
     @Test
     void testGetObjectsValidFilter_schema(){
-        when(jdbcManager.getDbMetaByDbId("key")).thenReturn(metadataMap.get("key"));
-        List<TableObject> expectedTableObject = metadataMap.get("key").dbTables().stream().map(TableObject::new).toList();
-        List<TableObject> actualTableObject = schemaController.getObjects("key","schema==schema");
-        assertEquals(expectedTableObject,actualTableObject);
-
-        actualTableObject = schemaController.getObjects("key","schema==notPresentInList");
-        assertEquals(0,actualTableObject.size());
+        testFilter("schema==schema", "schema==notPresentInList");
     }
-
     @Test
     void testGetObjectsValidFilter_name() {
-        when(jdbcManager.getDbMetaByDbId("key")).thenReturn(metadataMap.get("key"));
-        List<TableObject> expectedTableObject = metadataMap.get("key").dbTables().stream().map(TableObject::new).toList();
-        List<TableObject> actualTableObject = schemaController.getObjects("key","name==name");
-        assertEquals(expectedTableObject,actualTableObject);
-
-        actualTableObject = schemaController.getObjects("key","name==notPresentInList");
-        assertEquals(0,actualTableObject.size());
+        testFilter("name==name", "name==notPresentInList");
     }
     @Test
     void testGetObjectsValidFilter_type() {
-        when(jdbcManager.getDbMetaByDbId("key")).thenReturn(metadataMap.get("key"));
-        List<TableObject> expectedTableObject = metadataMap.get("key").dbTables().stream().map(TableObject::new).toList();
-        List<TableObject> actualTableObject = schemaController.getObjects("key","type==type");
-        assertEquals(expectedTableObject,actualTableObject);
-
-        actualTableObject = schemaController.getObjects("key","type==notPresentInList");
-        assertEquals(0,actualTableObject.size());
+        testFilter("type==type", "type==notPresentInList");
     }
     @Test
     void testGetObjectsValidFilter_invalidFieldFilter() {
         when(jdbcManager.getDbMetaByDbId("key")).thenReturn(metadataMap.get("key"));
-        List<TableObject> actualTableObject;
-        actualTableObject = schemaController.getObjects("key","invalidFilterField==notPresentInList");
+        List<TableObject> actualTableObject = getActualTableObject("invalidFilterField==notPresentInList");
         assertEquals(0,actualTableObject.size());
     }
     @Test
     void testGetObjectsDbIDInvalid(){
         when(jdbcManager.getDbMetaByDbId("key")).thenReturn(null);
-        assertEquals(0,schemaController.getObjects("key","filter").size());
-
+        assertEquals(0, schemaController.getObjects("key","filter", Boolean.FALSE).size());
+    }
+    @Test
+    void testGetObjectsWithColumns() {
+        when(jdbcManager.getDbMetaByDbId("key")).thenReturn(metadataMap.get("key"));
+        List<TableWithColumnsObject> expectedTableObject = metadataMap.get("key").dbTables().stream().map(TableWithColumnsObject::new).toList();
+        List<TableWithColumnsObject> actualTableObject = (List<TableWithColumnsObject>) schemaController.getObjects("key", null, Boolean.TRUE);
+        assertEquals(expectedTableObject, actualTableObject);
     }
 }


### PR DESCRIPTION
Before:

```json
{
  "schema": "public",
  "name": "django_migrations",
  "type": "TABLE"
}
```

After:

```json
{
  "schema": "public",
  "name": "django_migrations",
  "type": "TABLE",
  "columns": [
    {
      "name": "id",
      "pk": true,
      "dataType": "int4"
    },
    {
      "name": "app",
      "pk": false,
      "dataType": "varchar"
    },
    {
      "name": "name",
      "pk": false,
      "dataType": "varchar"
    },
    {
      "name": "applied",
      "pk": false,
      "dataType": "timestamptz"
    }
  ]
}
```