### PR TITLE
refactor(rest/rcp/controllers): Extracted a class from the repeated code within the RPC controllers 

### DIFF
--- a/api-rest/src/main/java/com/homihq/db2rest/jdbc/config/JdbcConfiguration.java
+++ b/api-rest/src/main/java/com/homihq/db2rest/jdbc/config/JdbcConfiguration.java
@@ -269,12 +269,12 @@ public class JdbcConfiguration {
 
     //RPC
     @Bean
-    public FunctionService functionService(JdbcManager jdbcManager) {
+    public RpcService functionService(JdbcManager jdbcManager) {
         return new JdbcFunctionService(jdbcManager);
     }
 
     @Bean
-    public ProcedureService procedureService(JdbcManager jdbcManager) {
+    public RpcService procedureService(JdbcManager jdbcManager) {
         return new JdbcProcedureService(jdbcManager);
     }
 
@@ -357,14 +357,14 @@ public class JdbcConfiguration {
 
     //RPC
     @Bean
-    @ConditionalOnBean(FunctionService.class)
-    public FunctionController functionController(FunctionService functionService) {
+    @ConditionalOnBean(RpcService.class)
+    public FunctionController functionController(RpcService functionService) {
         return new FunctionController(functionService);
     }
 
     @Bean
-    @ConditionalOnBean(ProcedureService.class)
-    public ProcedureController procedureController(ProcedureService procedureService) {
+    @ConditionalOnBean(RpcService.class)
+    public ProcedureController procedureController(RpcService procedureService) {
         return new ProcedureController(procedureService);
     }
 

--- a/api-rest/src/main/java/com/homihq/db2rest/jdbc/rest/RpcApi.java
+++ b/api-rest/src/main/java/com/homihq/db2rest/jdbc/rest/RpcApi.java
@@ -1,0 +1,24 @@
+package com.homihq.db2rest.jdbc.rest;
+
+import com.homihq.db2rest.jdbc.core.service.RpcService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Map;
+
+@Slf4j
+public abstract class RpcApi {
+    private final RpcService service;
+
+    protected RpcApi(RpcService service) {
+        this.service = service;
+    }
+
+    public ResponseEntity<Map<String, Object>> execute(
+            String dbId,
+            String funcName,
+            Map<String, Object> inParams) {
+        log.debug("Execute function {} with IN params {}", funcName, inParams.entrySet());
+        return ResponseEntity.ok(service.execute(dbId, funcName, inParams));
+    }
+}

--- a/api-rest/src/main/java/com/homihq/db2rest/jdbc/rest/rpc/FunctionController.java
+++ b/api-rest/src/main/java/com/homihq/db2rest/jdbc/rest/rpc/FunctionController.java
@@ -1,6 +1,7 @@
 package com.homihq.db2rest.jdbc.rest.rpc;
 
-import com.homihq.db2rest.jdbc.core.service.FunctionService;
+import com.homihq.db2rest.jdbc.core.service.RpcService;
+import com.homihq.db2rest.jdbc.rest.RpcApi;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -11,19 +12,16 @@ import static com.homihq.db2rest.jdbc.rest.RdbmsRestApi.VERSION;
 @RestController
 @RequestMapping(VERSION + "/{dbId}/function")
 @Slf4j
-@RequiredArgsConstructor
-public class FunctionController {
-
-    private final FunctionService functionService;
+public class FunctionController extends RpcApi {
+    public FunctionController(RpcService functionService) {
+        super(functionService);
+    }
 
     @PostMapping("/{funcName}")
     public ResponseEntity<Map<String, Object>> execute(
                 @PathVariable String dbId,
                 @PathVariable String funcName,
                 @RequestBody Map<String,Object> inParams) {
-
-        log.debug("Execute function {} with IN params {}", funcName, inParams.entrySet());
-
-        return ResponseEntity.ok(functionService.execute(dbId, funcName, inParams));
+        return super.execute(dbId, funcName, inParams);
     }
 }

--- a/api-rest/src/main/java/com/homihq/db2rest/jdbc/rest/rpc/ProcedureController.java
+++ b/api-rest/src/main/java/com/homihq/db2rest/jdbc/rest/rpc/ProcedureController.java
@@ -1,7 +1,7 @@
 package com.homihq.db2rest.jdbc.rest.rpc;
 
-import com.homihq.db2rest.jdbc.core.service.ProcedureService;
-import lombok.RequiredArgsConstructor;
+import com.homihq.db2rest.jdbc.core.service.RpcService;
+import com.homihq.db2rest.jdbc.rest.RpcApi;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -11,17 +11,17 @@ import static com.homihq.db2rest.jdbc.rest.RdbmsRestApi.VERSION;
 @RestController
 @RequestMapping(VERSION + "/{dbId}/procedure")
 @Slf4j
-@RequiredArgsConstructor
-public class ProcedureController {
+public class ProcedureController extends RpcApi {
+    public ProcedureController(RpcService procedureService) {
+        super(procedureService);
+    }
 
-    private final ProcedureService procedureService;
-
+    @Override
     @PostMapping("/{procName}")
     public ResponseEntity<Map<String, Object>> execute(
             @PathVariable String dbId,
             @PathVariable String procName,
-                                                       @RequestBody Map<String,Object> inParams) {
-        log.debug("Execute stored procedure {} with IN params {}", procName, inParams.entrySet());
-        return ResponseEntity.ok(procedureService.execute(dbId,procName, inParams));
+            @RequestBody Map<String,Object> inParams) {
+        return super.execute(dbId, procName, inParams);
     }
 }

--- a/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/core/service/JdbcFunctionService.java
+++ b/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/core/service/JdbcFunctionService.java
@@ -10,8 +10,7 @@ import java.util.Map;
 
 @Slf4j
 @RequiredArgsConstructor
-public class JdbcFunctionService implements FunctionService {
-
+public class JdbcFunctionService implements RpcService {
     private final JdbcManager jdbcManager;
 
     @Override

--- a/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/core/service/JdbcProcedureService.java
+++ b/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/core/service/JdbcProcedureService.java
@@ -15,9 +15,15 @@ import java.util.Map;
 
 @Slf4j
 @RequiredArgsConstructor
-public class JdbcProcedureService implements ProcedureService {
-
+public class JdbcProcedureService implements RpcService {
     private final JdbcManager jdbcManager;
+
+    @Override
+    public SimpleJdbcCall getSimpleJdbcCall(String dbId, String subRoutineName) {
+        log.info("dbId - {}", dbId);
+        JdbcTemplate jdbcTemplate = jdbcManager.getNamedParameterJdbcTemplate(dbId).getJdbcTemplate();
+        return new SimpleJdbcCall(jdbcTemplate).withProcedureName(subRoutineName);
+    }
 
     @Override
     public Map<String, Object> execute(String dbId, String subRoutineName, Map<String, Object> inParams) {

--- a/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/core/service/ProcedureService.java
+++ b/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/core/service/ProcedureService.java
@@ -1,9 +1,0 @@
-package com.homihq.db2rest.jdbc.core.service;
-
-
-import java.util.Map;
-
-public interface ProcedureService  {
-
-    Map<String, Object> execute(String dbId, String subRoutineName, Map<String, Object> inParams);
-}

--- a/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/core/service/RpcService.java
+++ b/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/core/service/RpcService.java
@@ -5,7 +5,7 @@ import org.springframework.jdbc.core.simple.SimpleJdbcCall;
 
 import java.util.Map;
 
-public interface FunctionService extends SubRoutine {
+public interface RpcService extends SubRoutine {
     SimpleJdbcCall getSimpleJdbcCall(String dbId, String subRoutineName);
     Map<String, Object> execute(String dbId, String subRoutineName, Map<String, Object> inParams);
 }


### PR DESCRIPTION
The common functionality of FunctionController and ProcedureController has been placed into a parent class, RpcApi. Merged FunctionService and ProcedureService into RpcService.

The goal of this is simply to reduce repeated code. If it is planned in the future for the FunctionController to have different functionality from the ProcedureController, feel free to reject this PR.