### PR TITLE
refactor(FileAuthDataProvider): Pushed down getUserByUsername

### DIFF
--- a/auth/src/main/java/com/homihq/db2rest/auth/AuthFilter.java
+++ b/auth/src/main/java/com/homihq/db2rest/auth/AuthFilter.java
@@ -21,7 +21,6 @@ import java.util.Objects;
 @RequiredArgsConstructor
 @Slf4j
 public class AuthFilter extends OncePerRequestFilter {
-
     private final AbstractAuthProvider authProvider;
     private final ObjectMapper objectMapper;
     private final UrlPathHelper urlPathHelper = new UrlPathHelper();
@@ -90,5 +89,4 @@ public class AuthFilter extends OncePerRequestFilter {
 
         objectMapper.writeValue(response.getWriter(), body);
     }
-
 }

--- a/auth/src/main/java/com/homihq/db2rest/auth/basic/BasicAuthProvider.java
+++ b/auth/src/main/java/com/homihq/db2rest/auth/basic/BasicAuthProvider.java
@@ -4,6 +4,7 @@ import com.homihq.db2rest.auth.common.AbstractAuthProvider;
 import com.homihq.db2rest.auth.common.AuthDataProvider;
 import com.homihq.db2rest.auth.common.User;
 import com.homihq.db2rest.auth.common.UserDetail;
+import com.homihq.db2rest.auth.data.FileAuthDataProvider;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -41,15 +42,14 @@ public class BasicAuthProvider extends AbstractAuthProvider {
         String username = parts[0];
         String password = parts[1];
 
-
-        Optional<User> user = authDataProvider.getUserByUsername(username);
-
-        if(user.isPresent() && StringUtils.equals(password, user.get().password())) {
-            return new UserDetail(username, user.get().roles());
+        if(authDataProvider instanceof FileAuthDataProvider fileAuthDataProvider) {
+            User user = fileAuthDataProvider.getUserByUsername(username).orElse(null);
+            if(user != null && StringUtils.equals(password, user.password())) {
+                return new UserDetail(username, user.roles());
+            }
         }
 
         return null;
-
     }
 
     @Override

--- a/auth/src/main/java/com/homihq/db2rest/auth/common/AuthDataProvider.java
+++ b/auth/src/main/java/com/homihq/db2rest/auth/common/AuthDataProvider.java
@@ -4,14 +4,9 @@ import java.util.List;
 import java.util.Optional;
 
 public interface AuthDataProvider {
-
     List<ResourceRole> getApiResourceRoles();
     List<User> getUsers();
     List<ApiExcludedResource> getExcludedResources();
 
     List<ApiKey> getApiKeys();
-
-    Optional<User> getUserByUsername(String username);
-
-
 }

--- a/auth/src/main/java/com/homihq/db2rest/auth/data/ApiAuthDataProvider.java
+++ b/auth/src/main/java/com/homihq/db2rest/auth/data/ApiAuthDataProvider.java
@@ -48,11 +48,4 @@ public class ApiAuthDataProvider implements AuthDataProvider {
     public List<ApiExcludedResource> getExcludedResources() {
         return List.of();
     }
-
-    @Override
-    public Optional<User> getUserByUsername(String username) {
-        return Optional.empty();
-    }
-
-
 }

--- a/auth/src/main/java/com/homihq/db2rest/auth/data/FileAuthDataProvider.java
+++ b/auth/src/main/java/com/homihq/db2rest/auth/data/FileAuthDataProvider.java
@@ -52,7 +52,6 @@ public class FileAuthDataProvider implements AuthDataProvider {
         return authDataSource.excludedResources();
     }
 
-    @Override
     public Optional<User> getUserByUsername(String username) {
         return getUsers().stream()
                 .filter(u -> StringUtils.equals(u.username(), username)).findFirst();

--- a/auth/src/main/java/com/homihq/db2rest/auth/data/NoAuthdataProvider.java
+++ b/auth/src/main/java/com/homihq/db2rest/auth/data/NoAuthdataProvider.java
@@ -27,11 +27,6 @@ public class NoAuthdataProvider implements AuthDataProvider {
     }
 
     @Override
-    public Optional<User> getUserByUsername(String username) {
-        return Optional.empty();
-    }
-
-    @Override
     public List<User> getUsers() {
         return List.of();
     }

--- a/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/sql/MetaDataExtraction.java
+++ b/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/sql/MetaDataExtraction.java
@@ -15,7 +15,6 @@ import static com.homihq.db2rest.jdbc.util.AliasGenerator.getAlias;
 public interface MetaDataExtraction {
     boolean canHandle(String database);
 
-
     List<DbTable> getTables(DatabaseMetaData databaseMetaData, boolean includeAllSchemas, List<String> includedSchemas);
 
     default boolean include(String schemaOrCatalog, List<String> excludedSchemasOrCatalogs) {

--- a/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/util/AliasGenerator.java
+++ b/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/util/AliasGenerator.java
@@ -5,8 +5,7 @@ package com.homihq.db2rest.jdbc.util;
 import java.util.Random;
 
 
-public class
-AliasGenerator {
+public class AliasGenerator {
     private static final Random random = new Random();
 
     public static String getAlias(String sqlIdentifier) {


### PR DESCRIPTION
Moved it down so it is a method of FileAuthDataProvider instead of being in AuthDataProvider. Since all other implementors of getUserByUsername instantly return Optional.empty(), I believe it is more appropriate to only implement the method in FileAuthDataProvider.