### PR TITLE
Clarify messaging for column not found

### DIFF
--- a/db2rest-common/src/main/java/com/homihq/db2rest/core/exception/InvalidColumnException.java
+++ b/db2rest-common/src/main/java/com/homihq/db2rest/core/exception/InvalidColumnException.java
@@ -3,7 +3,7 @@ package com.homihq.db2rest.core.exception;
 public class InvalidColumnException extends RuntimeException {
 
     public InvalidColumnException(String tableName, String columnName) {
-        super("Missing column " + tableName + "." + columnName);
+        super("Column not found " + tableName + "." + columnName);
     }
 
 }


### PR DESCRIPTION
- Because this is prefixed in the "detail" field output with "Failed to parse RQL - " then saying "missing" makes it seem like RQL had some problem parsing, when in fact, RQL had no problem at all, it was the DB that could not find a column.  It's better to say "not found" instead of "missing".