### PR TITLE
fix(rdbms-support) Replace int with UUID for table aliasing

### DIFF
--- a/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/util/AliasGenerator.java
+++ b/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/util/AliasGenerator.java
@@ -1,20 +1,24 @@
 package com.homihq.db2rest.jdbc.util;
 
-
-
-import java.util.Random;
-
+import java.util.UUID;
 
 public class
 AliasGenerator {
-    private static final Random random = new Random();
+    private static final int UUIDLength = 36;
+    private static final int UUIDNumChars = 12;
+
 
     public static String getAlias(String sqlIdentifier) {
         int LENGTH = 4;
         return
                 sqlIdentifier.length() > LENGTH ?
-                        sqlIdentifier.substring(0, LENGTH) + "_" + random.nextInt(100)
-                        : sqlIdentifier + "_" + random.nextInt(1000);
+                        sqlIdentifier.substring(0, LENGTH) + "_" + generateUUID()
+                        : sqlIdentifier + "_" + generateUUID();
 
+    }
+
+    private static String generateUUID (){
+        int startIndex = UUIDLength - UUIDNumChars;
+        return UUID.randomUUID().toString().substring(startIndex,UUIDLength);
     }
 }


### PR DESCRIPTION
Intends to fix #850 
We get the last 12 chars from a UUIDv4 to add a lot more randomness to the table alias generation.
With 1-1000 int range a collision is much more likely to happen leading to two different tables having the same alias which results in a SQL syntax error