### PR TITLE
Add Global CORS Configuration with Externalized Properties #859

### DIFF
--- a/api-rest/src/main/java/com/homihq/db2rest/config/WebMvcConfiguration.java
+++ b/api-rest/src/main/java/com/homihq/db2rest/config/WebMvcConfiguration.java
@@ -1,7 +1,7 @@
 package com.homihq.db2rest.config;
 
 import com.homihq.db2rest.interceptor.DatabaseContextRequestInterceptor;
-import com.homihq.db2rest.config.Db2RestConfigProperties;
+import com.homihq.db2rest.config.CorsConfig;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -19,7 +19,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class WebMvcConfiguration implements WebMvcConfigurer {
 
     @Autowired
-    Db2RestConfigProperties props;
+    CorsConfig props;
 
 
     private final DatabaseContextRequestInterceptor databaseContextRequestInterceptor;
@@ -31,13 +31,12 @@ public class WebMvcConfiguration implements WebMvcConfigurer {
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
-        String[] origins = Arrays.stream(props.getAllowedCorsList().split(","))
-                         .map(String::trim)
-                         .toArray(String[]::new);
-        for(String origin : origins){
-            System.out.println("*******************************************" + origin.toString() + "*****************************************************");
+        String[] origins = Arrays.stream(props.allowedCorsOrigin.split(",")).map(String::trim).toArray(String[]::new);
+        String[] headers = Arrays.stream(props.allowedCorsHeader.split(",")).map(String::trim).toArray(String[]::new);
+        String[] methods = Arrays.stream(props.allowedCorsMethods.split(",")).map(String::trim).toArray(String[]::new);
 
-        }
-        registry.addMapping("/**").allowedMethods("GET", "POST").allowedHeaders("*").allowedOrigins(origins);
+
+        System.out.println("================================== " + origins[0] + headers[0] + methods[0] + " ==============================");
+        registry.addMapping("/**").allowedMethods(methods).allowedHeaders(headers).allowedOrigins(origins);
     }
 }

--- a/api-rest/src/main/java/com/homihq/db2rest/config/WebMvcConfiguration.java
+++ b/api-rest/src/main/java/com/homihq/db2rest/config/WebMvcConfiguration.java
@@ -35,8 +35,8 @@ public class WebMvcConfiguration implements WebMvcConfigurer {
         String[] headers = Arrays.stream(props.allowedCorsHeader.split(",")).map(String::trim).toArray(String[]::new);
         String[] methods = Arrays.stream(props.allowedCorsMethods.split(",")).map(String::trim).toArray(String[]::new);
 
+        System.out.println( "Allowed Headers : " + props.allowedCorsHeader + " Allowed Methods : " +props.allowedCorsMethods + " Allowed Origins : " +props.allowedCorsOrigin);
 
-        System.out.println("================================== " + origins[0] + headers[0] + methods[0] + " ==============================");
         registry.addMapping("/**").allowedMethods(methods).allowedHeaders(headers).allowedOrigins(origins);
     }
 }

--- a/api-rest/src/main/java/com/homihq/db2rest/config/WebMvcConfiguration.java
+++ b/api-rest/src/main/java/com/homihq/db2rest/config/WebMvcConfiguration.java
@@ -1,9 +1,15 @@
 package com.homihq.db2rest.config;
 
 import com.homihq.db2rest.interceptor.DatabaseContextRequestInterceptor;
+import com.homihq.db2rest.config.Db2RestConfigProperties;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import java.util.Arrays;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -12,11 +18,26 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Slf4j
 public class WebMvcConfiguration implements WebMvcConfigurer {
 
+    @Autowired
+    Db2RestConfigProperties props;
+
 
     private final DatabaseContextRequestInterceptor databaseContextRequestInterceptor;
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(databaseContextRequestInterceptor);
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        String[] origins = Arrays.stream(props.getAllowedCorsList().split(","))
+                         .map(String::trim)
+                         .toArray(String[]::new);
+        for(String origin : origins){
+            System.out.println("*******************************************" + origin.toString() + "*****************************************************");
+
+        }
+        registry.addMapping("/**").allowedMethods("GET", "POST").allowedHeaders("*").allowedOrigins(origins);
     }
 }

--- a/api-rest/src/main/resources/application.yml
+++ b/api-rest/src/main/resources/application.yml
@@ -35,6 +35,10 @@ spring:
       max-file-size: 5MB
       max-request-size: 5MB
 
+corsconfig:
+  allowedCorsOrigin : ${CORS_ORIGIN_URL:*}
+  allowedCorsHeader : ${CORS_HEADERS_ALLOWED:*}
+  allowedCorsMethods : ${CORS_METHODS_ALLOWED:GET,POST}
 
 db2rest:
 
@@ -54,7 +58,6 @@ db2rest:
   defaultFetchLimit: ${DEFAULT_FETCH_LIMIT:100}
 
   allowSafeDelete : ${ALLOW_SAFE_DELETE:true}
-  allowedCorsList : ${CORS_ENABLED_URL:}
 
   multiTenancy:
     enabled: ${MULTI_TENANCY_ENABLED:false}

--- a/api-rest/src/main/resources/application.yml
+++ b/api-rest/src/main/resources/application.yml
@@ -54,6 +54,7 @@ db2rest:
   defaultFetchLimit: ${DEFAULT_FETCH_LIMIT:100}
 
   allowSafeDelete : ${ALLOW_SAFE_DELETE:true}
+  allowedCorsList : ${CORS_ENABLED_URL:}
 
   multiTenancy:
     enabled: ${MULTI_TENANCY_ENABLED:false}

--- a/rest-common/src/main/java/com/homihq/db2rest/config/CorsConfig.java
+++ b/rest-common/src/main/java/com/homihq/db2rest/config/CorsConfig.java
@@ -9,7 +9,7 @@ public class CorsConfig {
     public String allowedCorsOrigin;
     public String allowedCorsHeader;
     public String allowedCorsMethods;
-    
+
     public String getAllowedCorsOrigin() {
         return allowedCorsOrigin;
     }
@@ -27,8 +27,5 @@ public class CorsConfig {
     }
     public void setAllowedCorsMethods(String allowedCorsMethods) {
         this.allowedCorsMethods = allowedCorsMethods;
-    }
-
-    
-   
+    }   
 }

--- a/rest-common/src/main/java/com/homihq/db2rest/config/CorsConfig.java
+++ b/rest-common/src/main/java/com/homihq/db2rest/config/CorsConfig.java
@@ -1,0 +1,34 @@
+package com.homihq.db2rest.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "corsconfig")
+public class CorsConfig {
+    public String allowedCorsOrigin;
+    public String allowedCorsHeader;
+    public String allowedCorsMethods;
+    
+    public String getAllowedCorsOrigin() {
+        return allowedCorsOrigin;
+    }
+    public void setAllowedCorsOrigin(String allowedCorsOrigin) {
+        this.allowedCorsOrigin = allowedCorsOrigin;
+    }
+    public String getAllowedCorsHeader() {
+        return allowedCorsHeader;
+    }
+    public void setAllowedCorsHeader(String allowedCorsHeader) {
+        this.allowedCorsHeader = allowedCorsHeader;
+    }
+    public String getAllowedCorsMethods() {
+        return allowedCorsMethods;
+    }
+    public void setAllowedCorsMethods(String allowedCorsMethods) {
+        this.allowedCorsMethods = allowedCorsMethods;
+    }
+
+    
+   
+}

--- a/rest-common/src/main/java/com/homihq/db2rest/config/Db2RestConfigProperties.java
+++ b/rest-common/src/main/java/com/homihq/db2rest/config/Db2RestConfigProperties.java
@@ -31,12 +31,6 @@ public class Db2RestConfigProperties {
 
     private String templates;
 
-    private String allowedCorsList;
-    
-    public String getAllowedCorsList() {
-        return allowedCorsList;
-    }
-
     public boolean isAllSchema() {
 
         if (Objects.isNull(includeSchemas)) {

--- a/rest-common/src/main/java/com/homihq/db2rest/config/Db2RestConfigProperties.java
+++ b/rest-common/src/main/java/com/homihq/db2rest/config/Db2RestConfigProperties.java
@@ -31,6 +31,12 @@ public class Db2RestConfigProperties {
 
     private String templates;
 
+    private String allowedCorsList;
+    
+    public String getAllowedCorsList() {
+        return allowedCorsList;
+    }
+
     public boolean isAllSchema() {
 
         if (Objects.isNull(includeSchemas)) {


### PR DESCRIPTION
REF https://github.com/9tigerio/db2rest/issues/859

#### **Summary**  
This PR adds global CORS configuration to allow requests from specified origins, headers, and methods, with configurable values

#### **Changes Introduced**  
- Implemented `CorsConfig` class to read CORS settings from `application.yml`, allowing overrides via environment variables (`CORS_ORIGIN_URL`, `CORS_HEADERS_ALLOWED`, `CORS_METHODS_ALLOWED`).  
- Updated `WebMvcConfiguration` to apply global CORS rules using values from `CorsConfig`.  
- Ensured default values (`*`) are used if environment variables are not set.  

#### **How to Configure**  
CORS settings can now be modified at runtime by passing environment variables:  

```bash
java -jar db2rest.jar --CORS_ORIGIN_URL='http://localhost:9000' --CORS_HEADERS_ALLOWED='*' --CORS_METHODS_ALLOWED='GET,POST'
```

#### **Next Steps**  
- Review if additional security measures (e.g., specific methods, allowed credentials) should be enforced.  
- I have added default values which need to be reviewed before being merged
![image](https://github.com/user-attachments/assets/b3ae5e3e-ea7d-4069-9594-989b4d193d5c)
 

Would appreciate feedback and suggestions! 🚀