### PR TITLE
Fix(api-rest): Fix for UUID not getting properly sent to postgres. Fixes #880

### DIFF
--- a/rdbms-common/src/main/java/com/homihq/db2rest/jdbc/config/dialect/Dialect.java
+++ b/rdbms-common/src/main/java/com/homihq/db2rest/jdbc/config/dialect/Dialect.java
@@ -10,6 +10,7 @@ import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 public abstract class Dialect {
     private final ObjectMapper objectMapper;
@@ -56,16 +57,16 @@ public abstract class Dialect {
         return dbColumn.tableAlias() + "_" + dbColumn.name();
     }
 
-    public List<Object> parseListValues(List<String> values, Class type) {
+    public List<Object> parseListValues(List<String> values, Class type, String columnDatatypeName) {
         return
                 values.stream()
-                        .map(v -> processValue(v, type, null))
+                        .map(v -> processValue(v, type, null,columnDatatypeName))
                         .toList();
     }
 
     //TODO use Spring converter
     @Deprecated
-    public Object processValue(String value, Class<?> type, String format) {
+    public Object processValue(String value, Class<?> type, String format, String columnTypeName) {
         //System.out.println("type " + type);
         if (String.class == type) {
             //return "'" + value + "'";
@@ -83,7 +84,12 @@ public abstract class Dialect {
             return LocalDate.parse(value, DateTimeFormatter.ISO_DATE);
         } else if (java.sql.Timestamp.class == type) {
             return convertTimestamp(value);
-        } else {
+
+        }
+        else if (Object.class == type && "uuid".equals(columnTypeName)) {
+            return UUID.fromString(value);
+        }
+        else {
             return value;
         }
 

--- a/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/processor/RootWhereProcessor.java
+++ b/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/processor/RootWhereProcessor.java
@@ -12,6 +12,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.core.annotation.Order;
 
+import java.util.UUID;
+
 @Slf4j
 @Order(8)
 @RequiredArgsConstructor
@@ -37,6 +39,19 @@ public class RootWhereProcessor implements ReadProcessor {
 
             log.debug("Where - {}", where);
             log.debug("param map - {}", readContext.getParamMap());
+
+            for(String key : readContext.getParamMap().keySet()){
+                Object val = readContext.getParamMap().get(key);
+                try{
+                    if(!(val instanceof String))
+                        continue;
+                    UUID value = UUID.fromString((String)val);
+                    readContext.getParamMap().put(key, value);
+                }
+                catch (IllegalArgumentException e){
+                    continue;
+                }
+            }
 
             readContext.setRootWhere(where);
 

--- a/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/processor/RootWhereProcessor.java
+++ b/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/processor/RootWhereProcessor.java
@@ -12,7 +12,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.core.annotation.Order;
 
-import java.util.UUID;
 
 @Slf4j
 @Order(8)
@@ -39,19 +38,6 @@ public class RootWhereProcessor implements ReadProcessor {
 
             log.debug("Where - {}", where);
             log.debug("param map - {}", readContext.getParamMap());
-
-            for(String key : readContext.getParamMap().keySet()){
-                Object val = readContext.getParamMap().get(key);
-                try{
-                    if(!(val instanceof String))
-                        continue;
-                    UUID value = UUID.fromString((String)val);
-                    readContext.getParamMap().put(key, value);
-                }
-                catch (IllegalArgumentException e){
-                    continue;
-                }
-            }
 
             readContext.setRootWhere(where);
 

--- a/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/rsql/operator/handler/EqualToOperatorHandler.java
+++ b/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/rsql/operator/handler/EqualToOperatorHandler.java
@@ -14,7 +14,7 @@ public class EqualToOperatorHandler implements OperatorHandler {
     @Override
     public String handle(Dialect dialect, DbColumn column, DbWhere dbWhere, String value, Class type, Map<String, Object> paramMap) {
 
-        Object vo = dialect.processValue(value, type, null);
+        Object vo = dialect.processValue(value, type, null, column.columnDataTypeName());
 
         if (dialect.supportAlias()) {
             String key =

--- a/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/rsql/operator/handler/GreaterThanEqualToOperatorHandler.java
+++ b/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/rsql/operator/handler/GreaterThanEqualToOperatorHandler.java
@@ -14,7 +14,7 @@ public class GreaterThanEqualToOperatorHandler implements OperatorHandler {
     @Override
     public String handle(Dialect dialect, DbColumn column, DbWhere dbWhere, String value, Class type, Map<String, Object> paramMap) {
 
-        Object vo = dialect.processValue(value, type, null);
+        Object vo = dialect.processValue(value, type, null, column.columnDataTypeName());
 
         if (dialect.supportAlias()) {
             String key =

--- a/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/rsql/operator/handler/GreaterThanOperatorHandler.java
+++ b/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/rsql/operator/handler/GreaterThanOperatorHandler.java
@@ -19,7 +19,7 @@ public class GreaterThanOperatorHandler implements OperatorHandler {
         log.debug("value - {}", value);
         log.debug("type - {}", type);
 
-        Object vo = dialect.processValue(value, type, null);
+        Object vo = dialect.processValue(value, type, null, column.columnDataTypeName());
 
         if (dialect.supportAlias()) {
             String key =

--- a/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/rsql/operator/handler/InOperatorHandler.java
+++ b/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/rsql/operator/handler/InOperatorHandler.java
@@ -23,7 +23,7 @@ public class InOperatorHandler implements OperatorHandler {
     @Override
     public String handle(Dialect dialect, DbColumn column, DbWhere dbWhere, List<String> values, Class type, Map<String, Object> paramMap) {
 
-        List<Object> vo = dialect.parseListValues(values, type);
+        List<Object> vo = dialect.parseListValues(values, type,column.columnDataTypeName());
 
         if (dialect.supportAlias()) {
             String key =

--- a/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/rsql/operator/handler/JsonContainOperatorHandler.java
+++ b/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/rsql/operator/handler/JsonContainOperatorHandler.java
@@ -14,7 +14,7 @@ public class JsonContainOperatorHandler implements OperatorHandler {
     @Override
     public String handle(Dialect dialect, DbColumn column, DbWhere dbWhere, String value, Class type, Map<String, Object> paramMap) {
 
-        Object vo = dialect.processValue(value, type, null);
+        Object vo = dialect.processValue(value, type, null, column.columnDataTypeName());
 
         if (dialect.supportAlias()) {
             String key =

--- a/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/rsql/operator/handler/JsonbContainOperatorHandler.java
+++ b/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/rsql/operator/handler/JsonbContainOperatorHandler.java
@@ -14,7 +14,7 @@ public class JsonbContainOperatorHandler implements OperatorHandler {
     @Override
     public String handle(Dialect dialect, DbColumn column, DbWhere dbWhere, String value, Class type, Map<String, Object> paramMap) {
 
-        Object vo = dialect.processValue(value, type, null);
+        Object vo = dialect.processValue(value, type, null, column.columnDataTypeName());
 
         if (dialect.supportAlias()) {
             String key =

--- a/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/rsql/operator/handler/JsonbEqualToOperatorHandler.java
+++ b/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/rsql/operator/handler/JsonbEqualToOperatorHandler.java
@@ -14,7 +14,7 @@ public class JsonbEqualToOperatorHandler implements OperatorHandler {
     @Override
     public String handle(Dialect dialect, DbColumn column, DbWhere dbWhere, String value, Class type, Map<String, Object> paramMap) {
 
-        Object vo = dialect.processValue(value, type, null);
+        Object vo = dialect.processValue(value, type, null, column.columnDataTypeName());
 
         if (dialect.supportAlias()) {
             String key =

--- a/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/rsql/operator/handler/LessThanEqualToOperatorHandler.java
+++ b/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/rsql/operator/handler/LessThanEqualToOperatorHandler.java
@@ -13,7 +13,7 @@ public class LessThanEqualToOperatorHandler implements OperatorHandler {
 
     @Override
     public String handle(Dialect dialect, DbColumn column, DbWhere dbWhere, String value, Class type, Map<String, Object> paramMap) {
-        Object vo = dialect.processValue(value, type, null);
+        Object vo = dialect.processValue(value, type, null, column.columnDataTypeName());
 
         if (dialect.supportAlias()) {
             String key =

--- a/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/rsql/operator/handler/LessThanOperatorHandler.java
+++ b/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/rsql/operator/handler/LessThanOperatorHandler.java
@@ -13,7 +13,7 @@ public class LessThanOperatorHandler implements OperatorHandler {
 
     @Override
     public String handle(Dialect dialect, DbColumn column, DbWhere dbWhere, String value, Class type, Map<String, Object> paramMap) {
-        Object vo = dialect.processValue(value, type, null);
+        Object vo = dialect.processValue(value, type, null, column.columnDataTypeName());
 
         if (dialect.supportAlias()) {
 

--- a/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/rsql/operator/handler/NotEqualToOperatorHandler.java
+++ b/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/rsql/operator/handler/NotEqualToOperatorHandler.java
@@ -13,7 +13,7 @@ public class NotEqualToOperatorHandler implements OperatorHandler {
 
     @Override
     public String handle(Dialect dialect, DbColumn column, DbWhere dbWhere, String value, Class type, Map<String, Object> paramMap) {
-        Object vo = dialect.processValue(value, type, null);
+        Object vo = dialect.processValue(value, type, null, column.columnDataTypeName());
 
         if (dialect.supportAlias()) {
             String key =

--- a/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/rsql/operator/handler/NotInOperatorHandler.java
+++ b/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/rsql/operator/handler/NotInOperatorHandler.java
@@ -23,7 +23,7 @@ public class NotInOperatorHandler implements OperatorHandler {
     @Override
     public String handle(Dialect dialect, DbColumn column, DbWhere dbWhere, List<String> values, Class type, Map<String, Object> paramMap) {
 
-        List<Object> vo = dialect.parseListValues(values, type);
+        List<Object> vo = dialect.parseListValues(values, type,column.columnDataTypeName());
 
         if (dialect.supportAlias()) {
 


### PR DESCRIPTION
When we pass a UUID as a String object to Spring JDBC it is not able to query the postgres database properly leading to issues. 
Similar StackOverflow articles: https://stackoverflow.com/questions/55286397/how-to-compare-character-varying-varcar-to-uuid-in-postgresql

The solution is to cast the object to a valid UUID object and then send to Spring JDBC to query. 
Fixes #880 

