### PR TITLE
Add support for path-based primary key access (including composite keys) for read API

### DIFF
--- a/db2rest-api/api-rest/src/main/java/com/homihq/db2rest/config/DbServiceConfiguration.java
+++ b/db2rest-api/api-rest/src/main/java/com/homihq/db2rest/config/DbServiceConfiguration.java
@@ -164,6 +164,11 @@ public class DbServiceConfiguration {
         return new RootWhereProcessor(jdbcManager);
     }
 
+    @Bean
+    public PrimaryKeyProcessor primaryKeyProcessor() {
+        return new PrimaryKeyProcessor();
+    }
+
     //END ::: Processors
 
     //START ::: Validator

--- a/db2rest-api/api-rest/src/main/java/com/homihq/db2rest/rest/read/ReadController.java
+++ b/db2rest-api/api-rest/src/main/java/com/homihq/db2rest/rest/read/ReadController.java
@@ -89,4 +89,29 @@ public class ReadController {
         return readService.findAll(readContext);
     }
 
+    @GetMapping(value = VERSION + "/{dbId}/{tableName}/{primaryKey}", produces = "application/json")
+    public Object findByPrimaryKey(
+            @RequestAttribute(name = ROLEBASEDDATAFILTERS, required = false) List<RoleDataFilter> roleBasedDataFilters,
+            @PathVariable String dbId,
+            @PathVariable String tableName,
+            @PathVariable String primaryKey,
+            @RequestHeader(name = "Accept-Profile", required = false) String schemaName,
+            @RequestParam(required = false, defaultValue = "*") String fields) {
+
+        log.debug("primaryKey - {}", primaryKey);
+
+        ReadContext readContext = ReadContext.builder()
+                .dbId(dbId)
+                .schemaName(schemaName)
+                .tableName(tableName)
+                .PrimaryKey(primaryKey)
+                .fields(fields)
+                .limit(1)
+                .defaultFetchLimit(db2RestConfigProperties.getDefaultFetchLimit())
+                .build();
+
+
+        return readService.findAll(readContext);
+    }
+
 }

--- a/db2rest-api/api-rest/src/main/java/com/homihq/db2rest/rest/read/ReadController.java
+++ b/db2rest-api/api-rest/src/main/java/com/homihq/db2rest/rest/read/ReadController.java
@@ -96,7 +96,9 @@ public class ReadController {
             @PathVariable String tableName,
             @PathVariable String primaryKey,
             @RequestHeader(name = "Accept-Profile", required = false) String schemaName,
-            @RequestParam(required = false, defaultValue = "*") String fields) {
+            @RequestParam(required = false, defaultValue = "*") String fields,
+            @RequestParam(required = false, defaultValue = "") String filter
+    ) {
 
         log.debug("primaryKey - {}", primaryKey);
 
@@ -105,13 +107,14 @@ public class ReadController {
                 .schemaName(schemaName)
                 .tableName(tableName)
                 .PrimaryKey(primaryKey)
+                .filter(filter)
                 .fields(fields)
                 .limit(1)
                 .defaultFetchLimit(db2RestConfigProperties.getDefaultFetchLimit())
                 .build();
 
 
-        return readService.findAll(readContext);
+        return readService.findByPrimaryKey(readContext);
     }
 
 }

--- a/db2rest-core/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/core/service/JdbcReadService.java
+++ b/db2rest-core/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/core/service/JdbcReadService.java
@@ -46,6 +46,26 @@ public class JdbcReadService implements ReadService {
         }
     }
 
+    @Override
+    public Object findByPrimaryKey(ReadContext readContext) {
+        try {
+            for (ReadProcessor processor : processorList) {
+                processor.process(readContext);
+            }
+
+            String sql = sqlCreatorTemplate.query(readContext);
+
+            return dbOperationService.read(
+                    jdbcManager.getNamedParameterJdbcTemplate(readContext.getDbId()),
+                    readContext.getParamMap(), sql, jdbcManager.getDialect(readContext.getDbId()));
+        } catch (DataAccessException e) {
+            log.error("Error in read with primaryKey : ", e);
+            throw new GenericDataAccessException(e.getMostSpecificCause().getMessage());
+        } catch (Exception e) {
+            log.error("Error in read with primaryKey : ", e);
+            throw new GenericDataAccessException("Failed to parse RQL - " + e.getMessage());
+        }
+    }
 
 
 }

--- a/db2rest-core/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/core/service/ReadService.java
+++ b/db2rest-core/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/core/service/ReadService.java
@@ -4,4 +4,5 @@ import com.homihq.db2rest.jdbc.dto.ReadContext;
 
 public interface ReadService {
     Object findAll(ReadContext readContext);
+    Object findByPrimaryKey(ReadContext readContext);
 }

--- a/db2rest-core/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/dto/ReadContext.java
+++ b/db2rest-core/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/dto/ReadContext.java
@@ -28,6 +28,7 @@ public class ReadContext {
     String dbId;
     String schemaName;
     String tableName;
+    String PrimaryKey;
     String fields;
     String filter;
     List<String> sorts;

--- a/db2rest-core/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/processor/PrimaryKeyProcessor.java
+++ b/db2rest-core/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/processor/PrimaryKeyProcessor.java
@@ -35,12 +35,18 @@ public class PrimaryKeyProcessor implements ReadProcessor {
                 );
             }
 
-            String filter = IntStream.range(0, columns.size())
+            String pkFilter = IntStream.range(0, columns.size())
                     .mapToObj(i -> columns.get(i) + "==" + values.get(i))
                     .collect(Collectors.joining(";"));
 
-            log.debug("Filter - {}", filter);
-            readContext.setFilter(filter);
+            String existingFilter = readContext.getFilter();
+
+            if (StringUtils.isNoneBlank(existingFilter)) {
+                pkFilter = pkFilter + ";" + existingFilter;
+            }
+
+            log.debug("Filter - {}", pkFilter);
+            readContext.setFilter(pkFilter);
         }
     }
 }

--- a/db2rest-core/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/processor/PrimaryKeyProcessor.java
+++ b/db2rest-core/rdbms-support/src/main/java/com/homihq/db2rest/jdbc/processor/PrimaryKeyProcessor.java
@@ -1,0 +1,46 @@
+package com.homihq.db2rest.jdbc.processor;
+
+import com.db2rest.jdbc.dialect.model.DbColumn;
+import com.homihq.db2rest.jdbc.dto.ReadContext;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.core.annotation.Order;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Order(2)
+@Slf4j
+public class PrimaryKeyProcessor implements ReadProcessor {
+
+    @Override
+    public void process(ReadContext readContext) {
+        if (StringUtils.isNoneBlank(readContext.getPrimaryKey())) {
+
+            List<String> columns = readContext.getRoot()
+                    .buildPkColumns()
+                    .stream()
+                    .map(DbColumn::name)
+                    .sorted(String.CASE_INSENSITIVE_ORDER).toList();
+
+            List<String> values = Arrays.stream(readContext.getPrimaryKey().split(","))
+                    .map(String::trim)
+                    .toList();
+
+            if (columns.size() != values.size()) {
+                throw new IllegalArgumentException(
+                        "Expected " + columns.size() + " primary key values but got " + values.size()
+                );
+            }
+
+            String filter = IntStream.range(0, columns.size())
+                    .mapToObj(i -> columns.get(i) + "==" + values.get(i))
+                    .collect(Collectors.joining(";"));
+
+            log.debug("Filter - {}", filter);
+            readContext.setFilter(filter);
+        }
+    }
+}

--- a/db2rest-core/rdbms-support/src/test/java/com/homihq/db2rest/jdbc/processor/PrimaryKeyProcessorTest.java
+++ b/db2rest-core/rdbms-support/src/test/java/com/homihq/db2rest/jdbc/processor/PrimaryKeyProcessorTest.java
@@ -1,0 +1,77 @@
+package com.homihq.db2rest.jdbc.processor;
+
+import com.db2rest.jdbc.dialect.model.DbColumn;
+import com.homihq.db2rest.jdbc.dto.ReadContext;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import java.util.List;
+
+import com.db2rest.jdbc.dialect.model.DbTable;
+
+class PrimaryKeyProcessorTest {
+    private DbColumn pkColumn(String name) {
+        return new DbColumn("table", name, null, null, true, null, false, false, String.class, null, null);
+    }
+
+    @Test
+    void shouldCreateFilterForSinglePrimaryKey() {
+        ReadContext context = new ReadContext();
+        context.setPrimaryKey("1");
+
+        DbTable table = mock(DbTable.class);
+
+        when(table.buildPkColumns())
+                .thenReturn(List.of(
+                        pkColumn("id")
+                ));
+
+        context.setRoot(table);
+
+        new PrimaryKeyProcessor().process(context);
+
+        assertEquals("id==1", context.getFilter());
+    }
+
+    @Test
+    void shouldCreateFilterForMultiplePrimaryKeys() {
+        ReadContext context = new ReadContext();
+        context.setPrimaryKey("1,2");
+
+        DbTable table = mock(DbTable.class);
+
+        when(table.buildPkColumns())
+                .thenReturn(List.of(
+                        pkColumn("id"),
+                        pkColumn("type")
+                ));
+
+        context.setRoot(table);
+
+        new PrimaryKeyProcessor().process(context);
+
+        assertEquals("id==1;type==2", context.getFilter());
+    }
+
+    @Test
+    void shouldMergePrimaryKeyWithExistingFilter() {
+        ReadContext context = new ReadContext();
+        context.setPrimaryKey("1,2");
+        context.setFilter("comment==true");
+
+        DbTable table = mock(DbTable.class);
+
+        when(table.buildPkColumns())
+                .thenReturn(List.of(
+                        pkColumn("id"),
+                        pkColumn("type")
+                ));
+
+        context.setRoot(table);
+
+        new PrimaryKeyProcessor().process(context);
+
+        assertEquals("id==1;type==2;comment==true", context.getFilter());
+    }
+}


### PR DESCRIPTION
Fixes #835
This PR adds support for fetching records using path-based primary keys in the read API.

Previously, records were accessed using filter-based queries:
GET /v1/rdbms/{db}/{table}?filter=id==42

With this change, records can now be accessed using a more RESTful path:
GET /v1/rdbms/{db}/{table}/{value1,value2}

Key points:
- Supports both single and composite primary keys
- Primary key columns are retrieved and alphabetically sorted to ensure consistent mapping
- Input values are validated against the number of primary key columns
- Internally, the values are converted into the existing filter format using `Collectors.joining(";")`

If this approach is acceptable, I can extend the same logic to update and delete APIs in a follow-up PR.