### PR TITLE
fix(pg): resolve boolean type casting in filters 

### DIFF
--- a/db2rest-api/api-rest/src/test/java/com/homihq/db2rest/rest/pg/PgReadControllerTest.java
+++ b/db2rest-api/api-rest/src/test/java/com/homihq/db2rest/rest/pg/PgReadControllerTest.java
@@ -108,7 +108,7 @@ class PgReadControllerTest extends PostgreSQLBaseIntegrationTest {
     @Test
     @DisplayName("Test PostgreSQL boolean type casting in filter")
     void testBooleanFilterCasting() throws Exception {
-        mockMvc.perform(get("/v1/rdbms/pgsqldb/users?filter=isActive==true")
+        mockMvc.perform(get(VERSION + "/pgsqldb/users?filter=isActive==true")
                         .header("Accept-Profile", "public"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.[*]").isArray())

--- a/db2rest-api/api-rest/src/test/java/com/homihq/db2rest/rest/pg/PgReadControllerTest.java
+++ b/db2rest-api/api-rest/src/test/java/com/homihq/db2rest/rest/pg/PgReadControllerTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestClassOrder;
 import org.springframework.http.MediaType;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
 import java.util.Map;
 
@@ -102,5 +103,17 @@ class PgReadControllerTest extends PostgreSQLBaseIntegrationTest {
                 .andExpect(status().isOk())
                 //.andDo(print())
                 .andDo(document("pg-get-one-film"));
+    }
+
+    @Test
+    @DisplayName("Test PostgreSQL boolean type casting in filter")
+    void testBooleanFilterCasting() throws Exception {
+        mockMvc.perform(get("/v1/rdbms/pgsqldb/users?filter=isActive==true")
+                        .header("Accept-Profile", "public"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.[*]").isArray())
+                // Verify the first item actually parsed the boolean correctly
+                .andExpect(jsonPath("$.[0].isactive").value(true))
+                .andDo(print());
     }
 }

--- a/db2rest-core/rdbms-common/src/main/java/com/db2rest/jdbc/dialect/Dialect.java
+++ b/db2rest-core/rdbms-common/src/main/java/com/db2rest/jdbc/dialect/Dialect.java
@@ -71,16 +71,9 @@ public abstract class Dialect {
         if (String.class == type) {
             //return "'" + value + "'";
             return value;
-        }
-         else if (Boolean.class == type || boolean.class == type) {
+        } else if (Boolean.class == type || boolean.class == type) {
             return Boolean.valueOf(value);
-        }
-//        else if (Boolean.class == type || boolean.class == type) {
-//            Boolean aBoolean = Boolean.valueOf(value);
-//            return aBoolean ? "1" : "0";
-//        }
-
-        else if (Integer.class == type || int.class == type) {
+        } else if (Integer.class == type || int.class == type) {
             return Integer.valueOf(value);
         } else if (Long.class == type || long.class == type) {
             return Long.valueOf(value);

--- a/db2rest-core/rdbms-common/src/main/java/com/db2rest/jdbc/dialect/Dialect.java
+++ b/db2rest-core/rdbms-common/src/main/java/com/db2rest/jdbc/dialect/Dialect.java
@@ -71,10 +71,16 @@ public abstract class Dialect {
         if (String.class == type) {
             //return "'" + value + "'";
             return value;
-        } else if (Boolean.class == type || boolean.class == type) {
-            Boolean aBoolean = Boolean.valueOf(value);
-            return aBoolean ? "1" : "0";
-        } else if (Integer.class == type || int.class == type) {
+        }
+         else if (Boolean.class == type || boolean.class == type) {
+            return Boolean.valueOf(value);
+        }
+//        else if (Boolean.class == type || boolean.class == type) {
+//            Boolean aBoolean = Boolean.valueOf(value);
+//            return aBoolean ? "1" : "0";
+//        }
+
+        else if (Integer.class == type || int.class == type) {
             return Integer.valueOf(value);
         } else if (Long.class == type || long.class == type) {
             return Long.valueOf(value);


### PR DESCRIPTION
Closes #946
This PR fixes the issue where boolean filters (e.g., active==true) fail on PostgreSQL. The dialect was forcing booleans into '1'/'0' strings, which caused a type mismatch error. I've updated the dialect to return the native Boolean object and added a regression test in PgReadControllerTest using the existing users table.

