### PR TITLE
fix(api-rest): validate limit and offset on read endpoints

### DIFF
--- a/db2rest-api/api-rest/src/main/java/com/homihq/db2rest/rest/read/ReadController.java
+++ b/db2rest-api/api-rest/src/main/java/com/homihq/db2rest/rest/read/ReadController.java
@@ -3,6 +3,7 @@ package com.homihq.db2rest.rest.read;
 import com.homihq.db2rest.auth.data.RoleDataFilter;
 import com.homihq.db2rest.config.Db2RestConfigProperties;
 import com.homihq.db2rest.config.MultiTenancy;
+import com.homihq.db2rest.core.util.PaginationValidator;
 import com.homihq.db2rest.jdbc.core.service.ReadService;
 import com.homihq.db2rest.jdbc.dto.JoinDetail;
 import com.homihq.db2rest.jdbc.dto.ReadContext;
@@ -44,6 +45,8 @@ public class ReadController {
 
         log.debug("filter - {}", filter);
 
+        PaginationValidator.validate(limit, offset);
+
         ReadContext readContext = ReadContext.builder()
                 .dbId(dbId)
                 .schemaName(schemaName)
@@ -73,6 +76,8 @@ public class ReadController {
             @RequestParam(required = false, defaultValue = "-1") long offset,
             @RequestBody List<JoinDetail> joins
     ) {
+        PaginationValidator.validate(limit, offset);
+
         ReadContext readContext = ReadContext.builder()
                 .dbId(dbId)
                 .schemaName(schemaName)

--- a/db2rest-api/api-rest/src/test/java/com/homihq/db2rest/rest/pg/PgReadControllerPaginationValidationTest.java
+++ b/db2rest-api/api-rest/src/test/java/com/homihq/db2rest/rest/pg/PgReadControllerPaginationValidationTest.java
@@ -1,0 +1,54 @@
+package com.homihq.db2rest.rest.pg;
+
+import com.homihq.db2rest.PostgreSQLBaseIntegrationTest;
+import org.junit.jupiter.api.ClassOrderer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestClassOrder;
+import org.springframework.http.MediaType;
+
+import static com.homihq.db2rest.rest.RdbmsRestApi.VERSION;
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@TestClassOrder(ClassOrderer.OrderAnnotation.class)
+@Order(104)
+public class PgReadControllerPaginationValidationTest extends PostgreSQLBaseIntegrationTest {
+
+    @Test
+    @DisplayName("Reject invalid limit less than -1")
+    void rejectInvalidLimit() throws Exception {
+        mockMvc.perform(get(VERSION + "/pgsqldb/person")
+                        .param("limit", "-2")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.detail", containsString("limit")))
+                .andDo(document("pg-reject-invalid-pagination-limit"));
+    }
+
+    @Test
+    @DisplayName("Reject zero limit")
+    void rejectZeroLimit() throws Exception {
+        mockMvc.perform(get(VERSION + "/pgsqldb/person")
+                        .param("limit", "0")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.detail", containsString("limit")))
+                .andDo(document("pg-reject-zero-pagination-limit"));
+    }
+
+    @Test
+    @DisplayName("Reject invalid offset less than -1")
+    void rejectInvalidOffset() throws Exception {
+        mockMvc.perform(get(VERSION + "/pgsqldb/person")
+                        .param("offset", "-2")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.detail", containsString("offset")))
+                .andDo(document("pg-reject-invalid-pagination-offset"));
+    }
+}

--- a/db2rest-api/rest-common/src/main/java/com/homihq/db2rest/exception/GlobalExceptionHandler.java
+++ b/db2rest-api/rest-common/src/main/java/com/homihq/db2rest/exception/GlobalExceptionHandler.java
@@ -139,6 +139,16 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     }
 
+    @ExceptionHandler(InvalidPaginationParameterException.class)
+    ProblemDetail handleInvalidPaginationParameterException(InvalidPaginationParameterException e) {
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, e.getMessage());
+        problemDetail.setTitle("Invalid Pagination Parameter");
+        problemDetail.setType(URI.create("https://db2rest.com/error/invalid-pagination"));
+        problemDetail.setProperty("errorCategory", "Invalid-Pagination");
+        problemDetail.setProperty("timestamp", Instant.now());
+        return problemDetail;
+    }
+
     @ExceptionHandler({GenericDataAccessException.class, RuntimeException.class})
     ProblemDetail handleGenericDataAccessException(GenericDataAccessException e) {
         ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, e.getMessage());

--- a/db2rest-core/db2rest-common/src/main/java/com/homihq/db2rest/core/exception/InvalidPaginationParameterException.java
+++ b/db2rest-core/db2rest-common/src/main/java/com/homihq/db2rest/core/exception/InvalidPaginationParameterException.java
@@ -1,0 +1,8 @@
+package com.homihq.db2rest.core.exception;
+
+public class InvalidPaginationParameterException extends RuntimeException {
+
+    public InvalidPaginationParameterException(String parameter, String message) {
+        super("Invalid pagination parameter '" + parameter + "': " + message);
+    }
+}

--- a/db2rest-core/db2rest-common/src/main/java/com/homihq/db2rest/core/util/PaginationValidator.java
+++ b/db2rest-core/db2rest-common/src/main/java/com/homihq/db2rest/core/util/PaginationValidator.java
@@ -1,0 +1,26 @@
+package com.homihq.db2rest.core.util;
+
+import com.homihq.db2rest.core.exception.InvalidPaginationParameterException;
+
+public final class PaginationValidator {
+
+    private PaginationValidator() {
+    }
+
+    /**
+     * Validates read API pagination query parameters.
+     * <p>
+     * {@code limit}: {@code -1} applies the configured default fetch limit; any positive value is used as-is.
+     * {@code offset}: {@code -1} means no offset; any non-negative value is used as-is.
+     */
+    public static void validate(int limit, long offset) {
+        if (limit < -1 || limit == 0) {
+            throw new InvalidPaginationParameterException("limit",
+                    "must be -1 (use default fetch limit) or a positive integer.");
+        }
+        if (offset < -1) {
+            throw new InvalidPaginationParameterException("offset",
+                    "must be -1 (no offset) or a non-negative integer.");
+        }
+    }
+}

--- a/db2rest-core/rdbms-support/src/test/java/com/homihq/db2rest/core/util/PaginationValidatorTest.java
+++ b/db2rest-core/rdbms-support/src/test/java/com/homihq/db2rest/core/util/PaginationValidatorTest.java
@@ -1,0 +1,43 @@
+package com.homihq.db2rest.core.util;
+
+import com.homihq.db2rest.core.exception.InvalidPaginationParameterException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PaginationValidatorTest {
+
+    @Test
+    void shouldAcceptDefaultPaginationValues() {
+        assertThatNoException()
+                .isThrownBy(() -> PaginationValidator.validate(-1, -1));
+    }
+
+    @Test
+    void shouldAcceptExplicitLimitAndOffset() {
+        assertThatNoException()
+                .isThrownBy(() -> PaginationValidator.validate(10, 0));
+    }
+
+    @Test
+    void shouldRejectZeroLimit() {
+        assertThatThrownBy(() -> PaginationValidator.validate(0, -1))
+                .isInstanceOf(InvalidPaginationParameterException.class)
+                .hasMessageContaining("limit");
+    }
+
+    @Test
+    void shouldRejectLimitLessThanMinusOne() {
+        assertThatThrownBy(() -> PaginationValidator.validate(-2, -1))
+                .isInstanceOf(InvalidPaginationParameterException.class)
+                .hasMessageContaining("limit");
+    }
+
+    @Test
+    void shouldRejectOffsetLessThanMinusOne() {
+        assertThatThrownBy(() -> PaginationValidator.validate(-1, -2))
+                .isInstanceOf(InvalidPaginationParameterException.class)
+                .hasMessageContaining("offset");
+    }
+}


### PR DESCRIPTION
## Summary

Validates `limit` and `offset` on read endpoints before running queries.

Invalid values like `limit=-2` could skip the LIMIT clause and return unbounded results.

## Changes
- `PaginationValidator` + `InvalidPaginationParameterException`
- HTTP 400 `ProblemDetail` for bad pagination
- Unit + PostgreSQL integration tests

## Rules
- `limit`: `-1` (default) or `>= 1`
- `offset`: `-1` (none) or `>= 0`

## Test plan
- [x] `PaginationValidatorTest`
- [x] `PgReadControllerPaginationValidationTest`
- [ ] `mvn verify` (JDK 21 + Docker)