### PR TITLE
Multi tenancy: fix for users without matching roles seeing all tenants data 

### DIFF
--- a/db2rest-api/api-rest/src/main/java/com/homihq/db2rest/rest/create/BulkCreateController.java
+++ b/db2rest-api/api-rest/src/main/java/com/homihq/db2rest/rest/create/BulkCreateController.java
@@ -10,6 +10,8 @@ import com.homihq.db2rest.jdbc.core.service.BulkCreateService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -27,7 +29,7 @@ public class BulkCreateController implements BulkCreateRestApi {
     private final List<DataProcessor> dataProcessors;
 
     public CreateBulkResponse save(
-            List<RoleDataFilter> roleBasedDataFilters,
+            Pair<List<RoleDataFilter>, String[]> roleBasedDataFilters,
             String dbId,
             String tableName,
             String schemaName,
@@ -43,13 +45,14 @@ public class BulkCreateController implements BulkCreateRestApi {
 
         List<Map<String, Object>> data = dataProcessor.getData(request.getInputStream());
 
-        BulkContext context = new BulkContext(dbId, schemaName, tableName, includeColumns, tsIdEnabled, sequences, 0, roleBasedDataFilters);
+        BulkContext context = new BulkContext(dbId, schemaName, tableName, includeColumns, tsIdEnabled, sequences, 0,
+                roleBasedDataFilters);
         return bulkCreateService.saveBulk(context, data);
     }
 
     @Override
     public CompletableFuture<CreateResponse> saveMultipartFile(
-            List<RoleDataFilter> roleBasedDataFilters,
+            Pair<List<RoleDataFilter>, String[]> roleBasedDataFilters,
             String dbId,
             String tableName,
             String schemaName,
@@ -58,7 +61,8 @@ public class BulkCreateController implements BulkCreateRestApi {
             boolean tsIdEnabled,
             MultipartFile file) {
 
-        BulkContext context = new BulkContext(dbId, schemaName, tableName, includeColumns, tsIdEnabled, sequences, 0, roleBasedDataFilters);
+        BulkContext context = new BulkContext(dbId, schemaName, tableName, includeColumns, tsIdEnabled, sequences, 0,
+                roleBasedDataFilters);
         return bulkCreateService.saveMultipartFile(context, file);
     }
 }

--- a/db2rest-api/api-rest/src/main/java/com/homihq/db2rest/rest/create/BulkCreateRestApi.java
+++ b/db2rest-api/api-rest/src/main/java/com/homihq/db2rest/rest/create/BulkCreateRestApi.java
@@ -4,6 +4,8 @@ import com.homihq.db2rest.auth.data.RoleDataFilter;
 import com.homihq.db2rest.core.dto.CreateBulkResponse;
 import com.homihq.db2rest.core.dto.CreateResponse;
 import jakarta.servlet.http.HttpServletRequest;
+
+import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -20,28 +22,28 @@ import static com.homihq.db2rest.config.MultiTenancy.ROLEBASEDDATAFILTERS;
 import static com.homihq.db2rest.rest.RdbmsRestApi.VERSION;
 
 public interface BulkCreateRestApi {
-    @ResponseStatus(HttpStatus.CREATED)
-    @PostMapping(value = VERSION + "/{dbId}/{tableName}/bulk", consumes = {"application/json", "text/csv"})
-    CreateBulkResponse save(
-            @RequestAttribute(name = ROLEBASEDDATAFILTERS, required = false) List<RoleDataFilter> roleBasedDataFilters,
-            @PathVariable String dbId,
-            @PathVariable String tableName,
-            @RequestHeader(name = "Content-Profile", required = false) String schemaName,
-            @RequestParam(name = "columns", required = false) List<String> includeColumns,
-            @RequestParam(name = "sequences", required = false) List<String> sequences,
-            @RequestParam(name = "tsIdEnabled", required = false, defaultValue = "false") boolean tsIdEnabled,
-            HttpServletRequest request) throws Exception;
+        @ResponseStatus(HttpStatus.CREATED)
+        @PostMapping(value = VERSION + "/{dbId}/{tableName}/bulk", consumes = { "application/json", "text/csv" })
+        CreateBulkResponse save(
+                        @RequestAttribute(name = ROLEBASEDDATAFILTERS, required = false) Pair<List<RoleDataFilter>, String[]> roleBasedDataFilters,
+                        @PathVariable String dbId,
+                        @PathVariable String tableName,
+                        @RequestHeader(name = "Content-Profile", required = false) String schemaName,
+                        @RequestParam(name = "columns", required = false) List<String> includeColumns,
+                        @RequestParam(name = "sequences", required = false) List<String> sequences,
+                        @RequestParam(name = "tsIdEnabled", required = false, defaultValue = "false") boolean tsIdEnabled,
+                        HttpServletRequest request) throws Exception;
 
-
-    @ResponseStatus(HttpStatus.CREATED)
-    @PostMapping(value = VERSION + "/{dbId}/{tableName}/upload", consumes = {"multipart/form-data", "application/json"})
-    CompletableFuture<CreateResponse> saveMultipartFile(
-            @RequestAttribute(name = ROLEBASEDDATAFILTERS, required = false) List<RoleDataFilter> roleBasedDataFilters,
-            @PathVariable String dbId,
-            @PathVariable String tableName,
-            @RequestHeader(name = "Content-Profile", required = false) String schemaName,
-            @RequestParam(name = "columns", required = false) List<String> includeColumns,
-            @RequestParam(name = "sequences", required = false) List<String> sequences,
-            @RequestParam(name = "tsIdEnabled", required = false, defaultValue = "false") boolean tsIdEnabled,
-            @RequestParam("file") MultipartFile file) throws Exception;
+        @ResponseStatus(HttpStatus.CREATED)
+        @PostMapping(value = VERSION + "/{dbId}/{tableName}/upload", consumes = { "multipart/form-data",
+                        "application/json" })
+        CompletableFuture<CreateResponse> saveMultipartFile(
+                        @RequestAttribute(name = ROLEBASEDDATAFILTERS, required = false) Pair<List<RoleDataFilter>, String[]> roleBasedDataFilters,
+                        @PathVariable String dbId,
+                        @PathVariable String tableName,
+                        @RequestHeader(name = "Content-Profile", required = false) String schemaName,
+                        @RequestParam(name = "columns", required = false) List<String> includeColumns,
+                        @RequestParam(name = "sequences", required = false) List<String> sequences,
+                        @RequestParam(name = "tsIdEnabled", required = false, defaultValue = "false") boolean tsIdEnabled,
+                        @RequestParam("file") MultipartFile file) throws Exception;
 }

--- a/db2rest-api/api-rest/src/main/java/com/homihq/db2rest/rest/create/CreateController.java
+++ b/db2rest-api/api-rest/src/main/java/com/homihq/db2rest/rest/create/CreateController.java
@@ -3,6 +3,7 @@ package com.homihq.db2rest.rest.create;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.homihq.db2rest.auth.data.RoleDataFilter;
@@ -22,7 +23,7 @@ public class CreateController implements CreateRestApi {
 
     @Override
     public CreateResponse save(
-            List<RoleDataFilter> roleBasedDataFilters,
+            Pair<List<RoleDataFilter>, String[]> roleBasedDataFilters,
             String dbId, String schemaName,
             String tableName,
             List<String> includeColumns,

--- a/db2rest-api/api-rest/src/main/java/com/homihq/db2rest/rest/create/CreateRestApi.java
+++ b/db2rest-api/api-rest/src/main/java/com/homihq/db2rest/rest/create/CreateRestApi.java
@@ -6,6 +6,7 @@ import static com.homihq.db2rest.rest.RdbmsRestApi.VERSION;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,11 +18,12 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 
 import com.homihq.db2rest.auth.data.RoleDataFilter;
 import com.homihq.db2rest.core.dto.CreateResponse;
+
 public interface CreateRestApi {
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping(VERSION + "/{dbId}/{tableName}")
     CreateResponse save(
-            @RequestAttribute(name = ROLEBASEDDATAFILTERS, required = false) List<RoleDataFilter> roleBasedDataFilters,
+            @RequestAttribute(name = ROLEBASEDDATAFILTERS, required = false) Pair<List<RoleDataFilter>, String[]> roleBasedDataFilters,
             @PathVariable String dbId,
             @RequestHeader(name = "Content-Profile", required = false) String schemaName,
             @PathVariable String tableName,

--- a/db2rest-api/api-rest/src/main/java/com/homihq/db2rest/rest/delete/DeleteController.java
+++ b/db2rest-api/api-rest/src/main/java/com/homihq/db2rest/rest/delete/DeleteController.java
@@ -9,6 +9,8 @@ import com.homihq.db2rest.core.dto.DeleteResponse;
 import com.homihq.db2rest.jdbc.core.service.DeleteService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -21,12 +23,11 @@ public class DeleteController implements DeleteRestApi {
 
     @Override
     public DeleteResponse delete(
-            List<RoleDataFilter> roleBasedDataFilters,
+            Pair<List<RoleDataFilter>, String[]> roleBasedDataFilters,
             String dbId,
             String schemaName,
             String tableName,
-            String filter
-    ) {
+            String filter) {
 
         db2RestConfigProperties.checkDeleteAllowed(filter);
 

--- a/db2rest-api/api-rest/src/main/java/com/homihq/db2rest/rest/delete/DeleteRestApi.java
+++ b/db2rest-api/api-rest/src/main/java/com/homihq/db2rest/rest/delete/DeleteRestApi.java
@@ -2,6 +2,8 @@ package com.homihq.db2rest.rest.delete;
 
 import com.homihq.db2rest.auth.data.RoleDataFilter;
 import com.homihq.db2rest.core.dto.DeleteResponse;
+
+import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -19,7 +21,7 @@ public interface DeleteRestApi {
     @ResponseStatus(HttpStatus.OK)
     @DeleteMapping(VERSION + "/{dbId}/{tableName}")
     DeleteResponse delete(
-            @RequestAttribute(name = ROLEBASEDDATAFILTERS, required = false) List<RoleDataFilter> roleBasedDataFilters,
+            @RequestAttribute(name = ROLEBASEDDATAFILTERS, required = false) Pair<List<RoleDataFilter>, String[]> roleBasedDataFilters,
             @PathVariable String dbId,
             @RequestHeader(name = "Content-Profile", required = false) String schemaName,
             @PathVariable String tableName,

--- a/db2rest-api/api-rest/src/main/java/com/homihq/db2rest/rest/read/CountQueryController.java
+++ b/db2rest-api/api-rest/src/main/java/com/homihq/db2rest/rest/read/CountQueryController.java
@@ -7,6 +7,8 @@ import com.homihq.db2rest.jdbc.core.service.CountQueryService;
 import com.homihq.db2rest.jdbc.dto.ReadContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestAttribute;
@@ -28,7 +30,7 @@ public class CountQueryController {
 
     @GetMapping(VERSION + "/{dbId}/{tableName}/count")
     public CountResponse count(
-            @RequestAttribute(name = ROLEBASEDDATAFILTERS, required = false) List<RoleDataFilter> roleBasedDataFilters,
+            @RequestAttribute(name = ROLEBASEDDATAFILTERS, required = false) Pair<List<RoleDataFilter>, String[]> roleBasedDataFilters,
             @PathVariable String dbId,
             @PathVariable String tableName,
             @RequestHeader(name = "Accept-Profile", required = false) String schemaName,

--- a/db2rest-api/api-rest/src/main/java/com/homihq/db2rest/rest/read/ExistsQueryController.java
+++ b/db2rest-api/api-rest/src/main/java/com/homihq/db2rest/rest/read/ExistsQueryController.java
@@ -8,6 +8,8 @@ import com.homihq.db2rest.jdbc.dto.JoinDetail;
 import com.homihq.db2rest.jdbc.dto.ReadContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -31,7 +33,7 @@ public class ExistsQueryController {
 
     @GetMapping(value = VERSION + "/{dbId}/{tableName}/exists", produces = "application/json")
     public ExistsResponse exists(
-            @RequestAttribute(name = ROLEBASEDDATAFILTERS, required = false) List<RoleDataFilter> roleBasedDataFilters,
+            @RequestAttribute(name = ROLEBASEDDATAFILTERS, required = false) Pair<List<RoleDataFilter>, String[]> roleBasedDataFilters,
             @PathVariable String dbId,
             @PathVariable String tableName,
             @RequestHeader(name = "Accept-Profile", required = false) String schemaName,
@@ -50,15 +52,14 @@ public class ExistsQueryController {
         return existsQueryService.exists(readContext);
     }
 
-	@PostMapping(value = VERSION + "/{dbId}/{tableName}/exists/_expand", produces = "application/json")
-	public ExistsResponse exists(
-            @RequestAttribute(name = ROLEBASEDDATAFILTERS, required = false) List<RoleDataFilter> roleBasedDataFilters,
+    @PostMapping(value = VERSION + "/{dbId}/{tableName}/exists/_expand", produces = "application/json")
+    public ExistsResponse exists(
+            @RequestAttribute(name = ROLEBASEDDATAFILTERS, required = false) Pair<List<RoleDataFilter>, String[]> roleBasedDataFilters,
             @PathVariable String dbId,
             @PathVariable String tableName,
-            @RequestHeader(name="Accept-Profile", required = false) String schemaName,
+            @RequestHeader(name = "Accept-Profile", required = false) String schemaName,
             @RequestParam(name = "filter", required = false, defaultValue = "") String filter,
-            @RequestBody List<JoinDetail> joins
-	) {
+            @RequestBody List<JoinDetail> joins) {
 
         ReadContext readContext = ReadContext.builder()
                 .dbId(dbId)

--- a/db2rest-api/api-rest/src/main/java/com/homihq/db2rest/rest/read/FindOneController.java
+++ b/db2rest-api/api-rest/src/main/java/com/homihq/db2rest/rest/read/FindOneController.java
@@ -6,6 +6,8 @@ import com.homihq.db2rest.jdbc.core.service.FindOneService;
 import com.homihq.db2rest.jdbc.dto.ReadContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestAttribute;
@@ -28,13 +30,12 @@ public class FindOneController {
 
     @GetMapping(VERSION + "/{dbId}/{tableName}/one")
     public Map<String, Object> findOne(
-            @RequestAttribute(name = ROLEBASEDDATAFILTERS, required = false) List<RoleDataFilter> roleBasedDataFilters,
+            @RequestAttribute(name = ROLEBASEDDATAFILTERS, required = false) Pair<List<RoleDataFilter>, String[]> roleBasedDataFilters,
             @PathVariable String dbId,
             @PathVariable String tableName,
             @RequestHeader(name = "Accept-Profile", required = false) String schemaName,
             @RequestParam(name = "fields", required = false, defaultValue = "*") String fields,
             @RequestParam(name = "filter", required = false, defaultValue = "") String filter) {
-
 
         log.debug("tableName - {}", tableName);
         log.debug("fields - {}", fields);
@@ -42,7 +43,7 @@ public class FindOneController {
 
         ReadContext readContext = ReadContext.builder()
                 .dbId(dbId)
-                .defaultFetchLimit(100) //todo update with config
+                .defaultFetchLimit(100) // todo update with config
                 .schemaName(schemaName)
                 .tableName(tableName)
                 .filter(MultiTenancy.joinFilters(filter, dbId, tableName, roleBasedDataFilters))
@@ -51,6 +52,5 @@ public class FindOneController {
 
         return this.findOneService.findOne(readContext);
     }
-
 
 }

--- a/db2rest-api/api-rest/src/main/java/com/homihq/db2rest/rest/read/ReadController.java
+++ b/db2rest-api/api-rest/src/main/java/com/homihq/db2rest/rest/read/ReadController.java
@@ -22,104 +22,102 @@ import java.util.List;
 
 import static com.homihq.db2rest.config.MultiTenancy.ROLEBASEDDATAFILTERS;
 import static com.homihq.db2rest.rest.RdbmsRestApi.VERSION;
+import org.apache.commons.lang3.tuple.Pair;
 
 @RestController
 @Slf4j
 @RequiredArgsConstructor
 public class ReadController {
 
-    private final ReadService readService;
-    private final Db2RestConfigProperties db2RestConfigProperties;
+        private final ReadService readService;
+        private final Db2RestConfigProperties db2RestConfigProperties;
 
-    @GetMapping(value = VERSION + "/{dbId}/{tableName}", produces = "application/json")
-    public Object findAll(
-            @RequestAttribute(name = ROLEBASEDDATAFILTERS, required = false) List<RoleDataFilter> roleBasedDataFilters,
-            @PathVariable String dbId,
-            @PathVariable String tableName,
-            @RequestHeader(name = "Accept-Profile", required = false) String schemaName,
-            @RequestParam(required = false, defaultValue = "*") String fields,
-            @RequestParam(required = false, defaultValue = "") String filter,
-            @RequestParam(name = "sort", required = false, defaultValue = "") List<String> sorts,
-            @RequestParam(required = false, defaultValue = "-1") int limit,
-            @RequestParam(required = false, defaultValue = "-1") long offset) {
+        @GetMapping(value = VERSION + "/{dbId}/{tableName}", produces = "application/json")
+        public Object findAll(
+                        @RequestAttribute(name = ROLEBASEDDATAFILTERS, required = false) Pair<List<RoleDataFilter>, String[]> roleBasedDataFilters,
+                        @PathVariable String dbId,
+                        @PathVariable String tableName,
+                        @RequestHeader(name = "Accept-Profile", required = false) String schemaName,
+                        @RequestParam(required = false, defaultValue = "*") String fields,
+                        @RequestParam(required = false, defaultValue = "") String filter,
+                        @RequestParam(name = "sort", required = false, defaultValue = "") List<String> sorts,
+                        @RequestParam(required = false, defaultValue = "-1") int limit,
+                        @RequestParam(required = false, defaultValue = "-1") long offset) {
 
-        log.debug("filter - {}", filter);
+                log.debug("filter - {}", filter);
 
-        PaginationValidator.validate(limit, offset);
+                PaginationValidator.validate(limit, offset);
 
-        ReadContext readContext = ReadContext.builder()
-                .dbId(dbId)
-                .schemaName(schemaName)
-                .tableName(tableName)
-                .fields(fields)
-                .filter(MultiTenancy.joinFilters(filter, dbId, tableName, roleBasedDataFilters))
-                .sorts(sorts)
-                .limit(limit)
-                .defaultFetchLimit(db2RestConfigProperties.getDefaultFetchLimit())
-                .offset(offset)
-                .build();
+                ReadContext readContext = ReadContext.builder()
+                                .dbId(dbId)
+                                .schemaName(schemaName)
+                                .tableName(tableName)
+                                .fields(fields)
+                                .filter(MultiTenancy.joinFilters(filter, dbId, tableName, roleBasedDataFilters))
+                                .sorts(sorts)
+                                .limit(limit)
+                                .defaultFetchLimit(db2RestConfigProperties.getDefaultFetchLimit())
+                                .offset(offset)
+                                .build();
 
+                return readService.findAll(readContext);
+        }
 
-        return readService.findAll(readContext);
-    }
-
-    @PostMapping(value = VERSION + "/{dbId}/{tableName}/_expand", produces = "application/json")
-    public Object find(
-            @RequestAttribute(name = ROLEBASEDDATAFILTERS, required = false) List<RoleDataFilter> roleBasedDataFilters,
-            @PathVariable String dbId,
-            @PathVariable String tableName,
-            @RequestHeader(name = "Accept-Profile", required = false) String schemaName,
-            @RequestParam(required = false, defaultValue = "*") String fields,
-            @RequestParam(required = false, defaultValue = "") String filter,
-            @RequestParam(name = "sort", required = false, defaultValue = "") List<String> sorts,
-            @RequestParam(required = false, defaultValue = "-1") int limit,
-            @RequestParam(required = false, defaultValue = "-1") long offset,
+        @PostMapping(value = VERSION + "/{dbId}/{tableName}/_expand", produces = "application/json")
+        public Object find(
+                        @RequestAttribute(name = ROLEBASEDDATAFILTERS, required = false) Pair<List<RoleDataFilter>, String[]> roleBasedDataFilters,
+                        @PathVariable String dbId,
+                        @PathVariable String tableName,
+                        @RequestHeader(name = "Accept-Profile", required = false) String schemaName,
+                        @RequestParam(required = false, defaultValue = "*") String fields,
+                        @RequestParam(required = false, defaultValue = "") String filter,
+                        @RequestParam(name = "sort", required = false, defaultValue = "") List<String> sorts,
+                        @RequestParam(required = false, defaultValue = "-1") int limit,
+                        @RequestParam(required = false, defaultValue = "-1") long offset,
             @RequestBody List<JoinDetail> joins
     ) {
-        PaginationValidator.validate(limit, offset);
+                PaginationValidator.validate(limit, offset);
 
-        ReadContext readContext = ReadContext.builder()
-                .dbId(dbId)
-                .schemaName(schemaName)
-                .tableName(tableName)
-                .fields(fields)
-                .filter(MultiTenancy.joinFilters(filter, dbId, tableName, roleBasedDataFilters))
-                .sorts(sorts)
-                .limit(limit)
-                .defaultFetchLimit(db2RestConfigProperties.getDefaultFetchLimit())
-                .offset(offset)
-                .joins(joins)
-                .build();
+                ReadContext readContext = ReadContext.builder()
+                                .dbId(dbId)
+                                .schemaName(schemaName)
+                                .tableName(tableName)
+                                .fields(fields)
+                                .filter(MultiTenancy.joinFilters(filter, dbId, tableName, roleBasedDataFilters))
+                                .sorts(sorts)
+                                .limit(limit)
+                                .defaultFetchLimit(db2RestConfigProperties.getDefaultFetchLimit())
+                                .offset(offset)
+                                .joins(joins)
+                                .build();
 
-        return readService.findAll(readContext);
-    }
+                return readService.findAll(readContext);
+        }
 
-    @GetMapping(value = VERSION + "/{dbId}/{tableName}/{primaryKey}", produces = "application/json")
-    public Object findByPrimaryKey(
-            @RequestAttribute(name = ROLEBASEDDATAFILTERS, required = false) List<RoleDataFilter> roleBasedDataFilters,
-            @PathVariable String dbId,
-            @PathVariable String tableName,
-            @PathVariable String primaryKey,
-            @RequestHeader(name = "Accept-Profile", required = false) String schemaName,
-            @RequestParam(required = false, defaultValue = "*") String fields,
-            @RequestParam(required = false, defaultValue = "") String filter
-    ) {
+        @GetMapping(value = VERSION + "/{dbId}/{tableName}/{primaryKey}", produces = "application/json")
+        public Object findByPrimaryKey(
+                        @RequestAttribute(name = ROLEBASEDDATAFILTERS, required = false) Pair<List<RoleDataFilter>, String[]> roleBasedDataFilters,
+                        @PathVariable String dbId,
+                        @PathVariable String tableName,
+                        @PathVariable String primaryKey,
+                        @RequestHeader(name = "Accept-Profile", required = false) String schemaName,
+                        @RequestParam(required = false, defaultValue = "*") String fields,
+                        @RequestParam(required = false, defaultValue = "") String filter) {
 
-        log.debug("primaryKey - {}", primaryKey);
+                log.debug("primaryKey - {}", primaryKey);
 
-        ReadContext readContext = ReadContext.builder()
-                .dbId(dbId)
-                .schemaName(schemaName)
-                .tableName(tableName)
-                .PrimaryKey(primaryKey)
-                .filter(filter)
-                .fields(fields)
-                .limit(1)
-                .defaultFetchLimit(db2RestConfigProperties.getDefaultFetchLimit())
-                .build();
+                ReadContext readContext = ReadContext.builder()
+                                .dbId(dbId)
+                                .schemaName(schemaName)
+                                .tableName(tableName)
+                                .PrimaryKey(primaryKey)
+                                .filter(MultiTenancy.joinFilters(filter, dbId, tableName, roleBasedDataFilters))
+                                .fields(fields)
+                                .limit(1)
+                                .defaultFetchLimit(db2RestConfigProperties.getDefaultFetchLimit())
+                                .build();
 
-
-        return readService.findByPrimaryKey(readContext);
-    }
+                return readService.findByPrimaryKey(readContext);
+        }
 
 }

--- a/db2rest-api/api-rest/src/main/java/com/homihq/db2rest/rest/update/UpdateController.java
+++ b/db2rest-api/api-rest/src/main/java/com/homihq/db2rest/rest/update/UpdateController.java
@@ -6,6 +6,8 @@ import com.homihq.db2rest.core.dto.UpdateResponse;
 import com.homihq.db2rest.jdbc.core.service.UpdateService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestAttribute;
@@ -29,7 +31,7 @@ public class UpdateController {
 
     @PatchMapping(VERSION + "/{dbId}/{tableName}")
     public UpdateResponse save(
-            @RequestAttribute(name = ROLEBASEDDATAFILTERS, required = false) List<RoleDataFilter> roleBasedDataFilters,
+            @RequestAttribute(name = ROLEBASEDDATAFILTERS, required = false) Pair<List<RoleDataFilter>, String[]> roleBasedDataFilters,
             @PathVariable String dbId,
             @PathVariable String tableName,
             @RequestHeader(name = "Content-Profile", required = false) String schemaName,

--- a/db2rest-api/api-rest/src/test/java/com/homihq/db2rest/rest/pg/PgMultiTenancyTest.java
+++ b/db2rest-api/api-rest/src/test/java/com/homihq/db2rest/rest/pg/PgMultiTenancyTest.java
@@ -154,7 +154,7 @@ public class PgMultiTenancyTest extends PostgreSQLBaseIntegrationTest {
 
     @Test
     @Order(6)
-    @DisplayName("Query users without roleDataFilter - can only see rows without tenant_id")
+    @DisplayName("Query users without a TenantRole using roleDataFilter - MUST only return rows without any tenant_id")
     void userWithNoTenantRoleShouldSeeRowsWithoutTenantId() throws Exception {
         mockMvc.perform(get(VERSION + "/pgsqldb/users")
                 .contentType(APPLICATION_JSON).accept(APPLICATION_JSON)

--- a/db2rest-api/api-rest/src/test/java/com/homihq/db2rest/rest/pg/PgMultiTenancyTest.java
+++ b/db2rest-api/api-rest/src/test/java/com/homihq/db2rest/rest/pg/PgMultiTenancyTest.java
@@ -41,7 +41,10 @@ import io.hosuaby.inject.resources.junit.jupiter.TestWithResources;
 @TestWithResources
 public class PgMultiTenancyTest extends PostgreSQLBaseIntegrationTest {
 
-    private static final String BASIC_AUTH_VALUE = "Basic " + Base64.getEncoder().encodeToString("tom:32113".getBytes());
+    private static final String USER_TOM_BASIC_AUTH_VALUE = "Basic "
+            + Base64.getEncoder().encodeToString("tom:32113".getBytes());
+    private static final String USER_ROOT_BASIC_AUTH_VALUE = "Basic "
+            + Base64.getEncoder().encodeToString("root:23456".getBytes());
 
     @Autowired
     private AuthFilter authFilter;
@@ -49,10 +52,12 @@ public class PgMultiTenancyTest extends PostgreSQLBaseIntegrationTest {
     @GivenTextResource("/testdata/CREATE_USER_REQUEST.json")
     String CREATE_USER_REQUEST;
 
-    protected void createMockMvc(WebApplicationContext webApplicationContext, RestDocumentationContextProvider restDocumentation) {
+    protected void createMockMvc(WebApplicationContext webApplicationContext,
+            RestDocumentationContextProvider restDocumentation) {
         mockMvc = MockMvcBuilders
                 .webAppContextSetup(webApplicationContext)
-                .apply(documentationConfiguration(restDocumentation).snippets().withTemplateFormat(TemplateFormats.markdown()))
+                .apply(documentationConfiguration(restDocumentation).snippets()
+                        .withTemplateFormat(TemplateFormats.markdown()))
                 .addFilter(authFilter)
                 .build();
     }
@@ -62,10 +67,9 @@ public class PgMultiTenancyTest extends PostgreSQLBaseIntegrationTest {
     @DisplayName("Create users expect tenant_id to be filled")
     void create() throws Exception {
         mockMvc.perform(post(VERSION + "/pgsqldb/users/bulk")
-                        .contentType(APPLICATION_JSON).accept(APPLICATION_JSON)
-                        .content(CREATE_USER_REQUEST)
-                        .header("Authorization", BASIC_AUTH_VALUE)
-                )
+                .contentType(APPLICATION_JSON).accept(APPLICATION_JSON)
+                .content(CREATE_USER_REQUEST)
+                .header("Authorization", USER_TOM_BASIC_AUTH_VALUE))
                 .andDo(print())
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.rows").isArray())
@@ -78,9 +82,8 @@ public class PgMultiTenancyTest extends PostgreSQLBaseIntegrationTest {
     @DisplayName("Query all users for tenant_id, validate tenant_id")
     void findAllUsers() throws Exception {
         mockMvc.perform(get(VERSION + "/pgsqldb/users")
-                        .contentType(APPLICATION_JSON).accept(APPLICATION_JSON)
-                        .header("Authorization", BASIC_AUTH_VALUE)
-                )
+                .contentType(APPLICATION_JSON).accept(APPLICATION_JSON)
+                .header("Authorization", USER_TOM_BASIC_AUTH_VALUE))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$").isArray())
@@ -95,10 +98,9 @@ public class PgMultiTenancyTest extends PostgreSQLBaseIntegrationTest {
     @DisplayName("Query all users for tenant_id")
     void countAllUsers() throws Exception {
         mockMvc.perform(get(VERSION + "/pgsqldb/users/count")
-                        .contentType(APPLICATION_JSON).accept(APPLICATION_JSON)
-                        .header("Authorization", BASIC_AUTH_VALUE)
-                )
-//                .andDo(print())
+                .contentType(APPLICATION_JSON).accept(APPLICATION_JSON)
+                .header("Authorization", USER_TOM_BASIC_AUTH_VALUE))
+                // .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.*").isArray())
                 .andExpect(jsonPath("$.*", hasSize(1)))
@@ -111,9 +113,9 @@ public class PgMultiTenancyTest extends PostgreSQLBaseIntegrationTest {
     @DisplayName("update a user, tenant_id is ignored")
     void updateUsers() throws Exception {
         mockMvc.perform(patch(VERSION + "/pgsqldb/users?filter=auid==10")
-                        .contentType(APPLICATION_JSON).accept(APPLICATION_JSON)
-                        .header("Authorization", BASIC_AUTH_VALUE)
-                        .content("""
+                .contentType(APPLICATION_JSON).accept(APPLICATION_JSON)
+                .header("Authorization", USER_TOM_BASIC_AUTH_VALUE)
+                .content("""
                                 {
                                   "password": "blah",
                                   "tenant_id": 999
@@ -125,12 +127,11 @@ public class PgMultiTenancyTest extends PostgreSQLBaseIntegrationTest {
                 .andExpect(jsonPath("$.rows", equalTo(1)))
                 .andDo(document("pg-count-update-users-but-tenant-is-ignored"));
 
-        //validate tenant_id is not changed
+        // validate tenant_id is not changed
         mockMvc.perform(get(VERSION + "/pgsqldb/users?filter=auid==10")
                 .contentType(APPLICATION_JSON).accept(APPLICATION_JSON)
-                .header("Authorization", BASIC_AUTH_VALUE)
-                )
-//                .andDo(print())
+                .header("Authorization", USER_TOM_BASIC_AUTH_VALUE))
+                // .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.*", hasSize(1)))
                 .andExpect(jsonPath("$[0].tenant_id", not(equalTo(999))))
@@ -142,13 +143,24 @@ public class PgMultiTenancyTest extends PostgreSQLBaseIntegrationTest {
     @DisplayName("Delete all users for tenant_id")
     void deleteAllUsersFromTenant() throws Exception {
         mockMvc.perform(delete(VERSION + "/pgsqldb/users")
-                        .contentType(APPLICATION_JSON).accept(APPLICATION_JSON)
-                        .header("Authorization", BASIC_AUTH_VALUE)
-                )
-//                .andDo(print())
+                .contentType(APPLICATION_JSON).accept(APPLICATION_JSON)
+                .header("Authorization", USER_TOM_BASIC_AUTH_VALUE))
+                // .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.*", hasSize(1)))
                 .andExpect(jsonPath("$.rows", equalTo(2)))
                 .andDo(document("pg-delete-all-users-from-tenant"));
+    }
+
+    @Test
+    @Order(6)
+    @DisplayName("Query users without roleDataFilter - can only see rows without tenant_id")
+    void userWithNoTenantRoleShouldSeeRowsWithoutTenantId() throws Exception {
+        mockMvc.perform(get(VERSION + "/pgsqldb/users")
+                .contentType(APPLICATION_JSON).accept(APPLICATION_JSON)
+                .header("Authorization", USER_ROOT_BASIC_AUTH_VALUE))
+                // .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.*", hasSize(0)));
     }
 }

--- a/db2rest-api/api-rest/src/test/resources/pg/postgres-sakila.sql
+++ b/db2rest-api/api-rest/src/test/resources/pg/postgres-sakila.sql
@@ -234,6 +234,7 @@ CREATE TABLE student (
            last_name varchar(100) NOT NULL,
            email varchar(150) NOT NULL,
            phone varchar(20) NOT NULL,
+           tenant_id integer NOT NULL default 0,
            is_active integer NOT NULL,
            test_date varchar(20) NOT NULl
 );

--- a/db2rest-api/rest-common/src/main/java/com/homihq/db2rest/config/MultiTenancy.java
+++ b/db2rest-api/rest-common/src/main/java/com/homihq/db2rest/config/MultiTenancy.java
@@ -50,7 +50,8 @@ public class MultiTenancy {
         }
         List<RoleDataFilter> retval = new ArrayList<>();
         for (String role : userRoles) {
-            retval.addAll(roleDataFilters.stream().filter(rd -> role.equalsIgnoreCase(rd.role())).toList());
+            retval.addAll(roleDataFilters.stream().filter(rd -> role.equalsIgnoreCase(rd.role())
+                    && rd.dbId().equals(dbId) && rd.table().equals(table)).toList());
         }
         if (retval.isEmpty() && filterTenantColumn != null) {
             // when a tenant column is defined for the table, but the user has no roles, we add a filter to only see null value rows

--- a/db2rest-api/rest-common/src/main/java/com/homihq/db2rest/config/MultiTenancy.java
+++ b/db2rest-api/rest-common/src/main/java/com/homihq/db2rest/config/MultiTenancy.java
@@ -1,7 +1,10 @@
 package com.homihq.db2rest.config;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+
+import org.apache.commons.lang3.tuple.Pair;
 
 import com.homihq.db2rest.auth.data.RoleDataFilter;
 
@@ -12,14 +15,22 @@ import lombok.NoArgsConstructor;
 public class MultiTenancy {
     public static final String ROLEBASEDDATAFILTERS = "roleBasedDataFilters";
 
-    public static String joinFilters(String filter, String dbId, String table, List<RoleDataFilter> roleBasedDataFilters) {
+    public static String joinFilters(String filter, String dbId, String table,
+            Pair<List<RoleDataFilter>, String[]> roleBasedDataFilters) {
         StringBuilder filterBuilder = new StringBuilder(filter);
         if (roleBasedDataFilters != null) {
-            for (RoleDataFilter roleDataFilter : roleBasedDataFilters) {
+            for (RoleDataFilter roleDataFilter : getUserRoleBasedDataFilters(dbId, table,
+                    roleBasedDataFilters.getLeft(), roleBasedDataFilters.getRight())) {
                 if (dbId.equalsIgnoreCase(roleDataFilter.dbId()) && table.equalsIgnoreCase(roleDataFilter.table())) {
-                    if (!filterBuilder.isEmpty()) filterBuilder.append(";");
+                    if (!filterBuilder.isEmpty())
+                        filterBuilder.append(";");
                     filterBuilder.append(roleDataFilter.column());
-                    filterBuilder.append("==");
+                    if (roleDataFilter.value() == null) {
+                        filterBuilder.append("=isnull=");
+                    }
+                    else {
+                        filterBuilder.append("==");
+                    }
                     filterBuilder.append(roleDataFilter.value());
                 }
             }
@@ -27,18 +38,40 @@ public class MultiTenancy {
         return filterBuilder.toString();
     }
 
-    public static void addTenantColumns(List<Map<String, Object>> data, String dbId, String table, List<RoleDataFilter> roleBasedDataFilters) {
-        for(Map<String, Object> dataItem : data) {
+    private static List<RoleDataFilter> getUserRoleBasedDataFilters(String dbId, String table,
+            List<RoleDataFilter> roleDataFilters,
+            String[] userRoles) {
+        String filterTenantColumn = null;
+        for (RoleDataFilter roleDataFilter : roleDataFilters) {
+            if (dbId.equalsIgnoreCase(roleDataFilter.dbId()) && table.equalsIgnoreCase(roleDataFilter.table())) {
+                filterTenantColumn = roleDataFilter.column();
+                break;
+            }
+        }
+        List<RoleDataFilter> retval = new ArrayList<>();
+        for (String role : userRoles) {
+            retval.addAll(roleDataFilters.stream().filter(rd -> role.equalsIgnoreCase(rd.role())).toList());
+        }
+        if (retval.isEmpty() && filterTenantColumn != null) {
+            // when a tenant column is defined for the table, but the user has no roles, we add a filter to only see null value rows
+            retval.add(new RoleDataFilter("see_null_values_only", dbId, table, filterTenantColumn, null));
+        }
+        return retval;
+    }
+
+    public static void addTenantColumns(List<Map<String, Object>> data, String dbId, String table,
+            Pair<List<RoleDataFilter>, String[]> roleBasedDataFilters) {
+        for (Map<String, Object> dataItem : data) {
             addTenantColumns(dataItem, dbId, table, roleBasedDataFilters);
         }
     }
 
-    public static void addTenantColumns(Map<String, Object> data, String dbId, String table, List<RoleDataFilter> roleBasedDataFilters) {
+    public static void addTenantColumns(Map<String, Object> data, String dbId, String table,
+            Pair<List<RoleDataFilter>, String[]> roleBasedDataFilters) {
         if (roleBasedDataFilters != null) {
-            for (RoleDataFilter roleDataFilter : roleBasedDataFilters) {
-                if (dbId.equalsIgnoreCase(roleDataFilter.dbId()) && table.equalsIgnoreCase(roleDataFilter.table())) {
-                    data.put(roleDataFilter.column(), roleDataFilter.value());
-                }
+            for (RoleDataFilter roleDataFilter : getUserRoleBasedDataFilters(dbId, table,
+                    roleBasedDataFilters.getLeft(), roleBasedDataFilters.getRight())) {
+                data.put(roleDataFilter.column(), roleDataFilter.value());
             }
         }
     }

--- a/db2rest-api/rest-common/src/main/java/com/homihq/db2rest/dtos/BulkContext.java
+++ b/db2rest-api/rest-common/src/main/java/com/homihq/db2rest/dtos/BulkContext.java
@@ -2,16 +2,17 @@ package com.homihq.db2rest.dtos;
 
 import java.util.List;
 
+import org.apache.commons.lang3.tuple.Pair;
+
 import com.homihq.db2rest.auth.data.RoleDataFilter;
 
 public record BulkContext(
-        String dbId,
-        String schemaName,
-        String tableName,
-        List<String> includeColumns,
-        boolean tsIdEnabled,
-        List<String> sequences,
-        int rows,
-        List<RoleDataFilter> roleDataFilters
-) {
+                String dbId,
+                String schemaName,
+                String tableName,
+                List<String> includeColumns,
+                boolean tsIdEnabled,
+                List<String> sequences,
+                int rows,
+                Pair<List<RoleDataFilter>, String[]> roleDataFilters) {
 }

--- a/db2rest-auth/src/main/java/com/homihq/db2rest/auth/AuthFilter.java
+++ b/db2rest-auth/src/main/java/com/homihq/db2rest/auth/AuthFilter.java
@@ -9,6 +9,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.http.MediaType;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.util.UrlPathHelper;
@@ -21,7 +23,7 @@ import java.util.Objects;
 @RequiredArgsConstructor
 @Slf4j
 public class AuthFilter extends OncePerRequestFilter {
-
+    public static final String ROLEBASEDDATAFILTERS = "roleBasedDataFilters";
     private final AbstractAuthProvider authProvider;
     private final ObjectMapper objectMapper;
     private final UrlPathHelper urlPathHelper = new UrlPathHelper();
@@ -30,8 +32,7 @@ public class AuthFilter extends OncePerRequestFilter {
     protected void doFilterInternal(
             final HttpServletRequest request,
             final HttpServletResponse response,
-            final FilterChain filterChain
-    ) throws ServletException, IOException {
+            final FilterChain filterChain) throws ServletException, IOException {
 
         log.debug("Handling Auth");
 
@@ -42,7 +43,7 @@ public class AuthFilter extends OncePerRequestFilter {
 
         if (!authProvider.isExcluded(requestUri, method)) {
 
-            //authenticate
+            // authenticate
             UserDetail userDetail = authProvider.authenticate(request);
 
             log.debug("user detail - {}", userDetail);
@@ -53,14 +54,15 @@ public class AuthFilter extends OncePerRequestFilter {
                 return;
             }
 
-            //authorize
+            // authorize
             boolean authorized = authProvider.authorize(userDetail, requestUri, method);
             if (!authorized) {
                 String errorMessage = "Authorization failure.";
                 addError(errorMessage, request, response);
                 return;
             }
-            request.setAttribute("roleBasedDataFilters", authProvider.getRoleBasedDataFilters(userDetail));
+            request.setAttribute(ROLEBASEDDATAFILTERS,
+                    new ImmutablePair<>(authProvider.getRoleDataFilters(), userDetail.getRoles()));
         } else {
             log.debug("URI in whitelist. Security checks not applied.");
         }

--- a/db2rest-auth/src/main/java/com/homihq/db2rest/auth/data/AuthData.java
+++ b/db2rest-auth/src/main/java/com/homihq/db2rest/auth/data/AuthData.java
@@ -14,4 +14,9 @@ public record AuthData(
     public List<ApiExcludedResource> excludedResources() {
         return excludedResources == null ? List.of() : excludedResources;
     }
+
+    @Override
+    public List<RoleDataFilter> roleDataFilters() {
+        return roleDataFilters == null ? List.of() : roleDataFilters;
+    }
 }

--- a/db2rest-auth/src/main/java/com/homihq/db2rest/auth/datalookup/ApiAuthDataLookup.java
+++ b/db2rest-auth/src/main/java/com/homihq/db2rest/auth/datalookup/ApiAuthDataLookup.java
@@ -55,7 +55,7 @@ public class ApiAuthDataLookup implements AuthDataLookup {
     }
 
     @Override
-    public List<RoleDataFilter> getRoleDataFilters(String role) {
-        return authData.roleDataFilters().stream().filter(df -> role.equalsIgnoreCase(df.role())).toList();
+    public List<RoleDataFilter> getRoleDataFilters() {
+        return authData.roleDataFilters();
     }
 }

--- a/db2rest-auth/src/main/java/com/homihq/db2rest/auth/datalookup/AuthDataLookup.java
+++ b/db2rest-auth/src/main/java/com/homihq/db2rest/auth/datalookup/AuthDataLookup.java
@@ -17,5 +17,5 @@ public interface AuthDataLookup {
 
     Optional<User> getUserByUsername(String username);
 
-    List<RoleDataFilter> getRoleDataFilters(String role);
+    List<RoleDataFilter> getRoleDataFilters();
 }

--- a/db2rest-auth/src/main/java/com/homihq/db2rest/auth/datalookup/FileAuthDataLookup.java
+++ b/db2rest-auth/src/main/java/com/homihq/db2rest/auth/datalookup/FileAuthDataLookup.java
@@ -25,7 +25,6 @@ public class FileAuthDataLookup implements AuthDataLookup {
 
             log.debug("authDataSource - {}", authData);
 
-
         } catch (Exception e) {
 
             log.error("Unable to load auth data: ", e);
@@ -59,7 +58,7 @@ public class FileAuthDataLookup implements AuthDataLookup {
     }
 
     @Override
-    public List<RoleDataFilter> getRoleDataFilters(String role) {
-        return authData.roleDataFilters().stream().filter(df -> role.equalsIgnoreCase(df.role())).toList();
+    public List<RoleDataFilter> getRoleDataFilters() {
+        return authData.roleDataFilters();
     }
 }

--- a/db2rest-auth/src/main/java/com/homihq/db2rest/auth/datalookup/NoAuthdataLookup.java
+++ b/db2rest-auth/src/main/java/com/homihq/db2rest/auth/datalookup/NoAuthdataLookup.java
@@ -1,6 +1,5 @@
 package com.homihq.db2rest.auth.datalookup;
 
-
 import com.homihq.db2rest.auth.data.*;
 
 import java.util.List;
@@ -28,7 +27,7 @@ public class NoAuthdataLookup implements AuthDataLookup {
     }
 
     @Override
-    public List<RoleDataFilter> getRoleDataFilters(String role) {
+    public List<RoleDataFilter> getRoleDataFilters() {
         return List.of();
     }
 

--- a/db2rest-auth/src/main/java/com/homihq/db2rest/auth/provider/AbstractAuthProvider.java
+++ b/db2rest-auth/src/main/java/com/homihq/db2rest/auth/provider/AbstractAuthProvider.java
@@ -11,7 +11,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.util.AntPathMatcher;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -24,7 +23,7 @@ public abstract class AbstractAuthProvider {
 
     private static final String AUTH_HEADER = "Authorization";
 
-    private final String[] DEFAULT_WHITELIST = {"/swagger-ui/**", "/v3/api-docs/**", "/actuator/**"};
+    private final String[] DEFAULT_WHITELIST = { "/swagger-ui/**", "/v3/api-docs/**", "/actuator/**" };
 
     public abstract boolean canHandle(HttpServletRequest request);
 
@@ -43,17 +42,14 @@ public abstract class AbstractAuthProvider {
 
         //check in default whitelist first
 
-        boolean match =
-                Arrays.stream(DEFAULT_WHITELIST)
-                        .anyMatch(r -> antPathMatcher.match(r, requestUri));
+        boolean match = Arrays.stream(DEFAULT_WHITELIST)
+                .anyMatch(r -> antPathMatcher.match(r, requestUri));
 
         if (!match) {
 
-            return
-                    excludedResources
-                            .stream()
-                            .anyMatch(r ->
-                                    (antPathMatcher.match(r.resource(), requestUri)
+            return excludedResources
+                    .stream()
+                    .anyMatch(r -> (antPathMatcher.match(r.resource(), requestUri)
                                             && StringUtils.equalsIgnoreCase(r.method(), method))
                             );
         }
@@ -76,18 +72,17 @@ public abstract class AbstractAuthProvider {
         //resource mapping
         Optional<ResourceRole> resourceRole =
                 resourceRoleList
-                        .stream()
-                        .filter(r -> antPathMatcher.match(r.resource(), requestUri))
-                        .filter(r -> StringUtils.equalsIgnoreCase(r.method(), method))
-                        .findFirst();
+                .stream()
+                .filter(r -> antPathMatcher.match(r.resource(), requestUri))
+                .filter(r -> StringUtils.equalsIgnoreCase(r.method(), method))
+                .findFirst();
 
         //resource to role mapping
         if (resourceRole.isPresent()) {
             ResourceRole rr = resourceRole.get();
-            boolean roleMatch =
-                    rr.roles()
-                            .stream()
-                            .anyMatch(role -> StringUtils.equalsAnyIgnoreCase(role, userDetail.getRoles()));
+            boolean roleMatch = rr.roles()
+                    .stream()
+                    .anyMatch(role -> StringUtils.equalsAnyIgnoreCase(role, userDetail.getRoles()));
 
             log.debug("Role match result - {}", roleMatch);
 
@@ -100,11 +95,7 @@ public abstract class AbstractAuthProvider {
         return false;
     }
 
-    public List<RoleDataFilter> getRoleBasedDataFilters(UserDetail userDetail) {
-        List<RoleDataFilter> retval = new ArrayList<>();
-        for (String role : userDetail.getRoles()) {
-            retval.addAll(authDataLookup.getRoleDataFilters(role));
-        }
-        return retval;
+    public List<RoleDataFilter> getRoleDataFilters() {
+        return authDataLookup.getRoleDataFilters();
     }
 }

--- a/db2rest-auth/src/main/resources/auth-sample.yml
+++ b/db2rest-auth/src/main/resources/auth-sample.yml
@@ -58,3 +58,8 @@ roleDataFilters:
     table: users
     column: tenant_id
     value: 13
+  - role: role1
+    dbId: pgsqldb
+    table: student
+    column: tenant_id
+    value: 1

--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,23 @@
 
 
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
     <profiles>
         <profile>
             <id>release</id>


### PR DESCRIPTION
When using column based multi tenancy and a user does not have a role matching the roleDataFilters they can see all tenants data in a table having column based multi tenancy. This PR fixes this scenario by allowing them to see only the rows where the tenant id column value is not defined (is null) in case these are present. 