### PR TITLE
oauth jwt roles support

### DIFF
--- a/db2rest-auth/src/main/java/com/homihq/db2rest/auth/AuthConfiguration.java
+++ b/db2rest-auth/src/main/java/com/homihq/db2rest/auth/AuthConfiguration.java
@@ -68,9 +68,11 @@ public class AuthConfiguration {
     @ConditionalOnProperty(prefix = "db2rest.auth", name = "provider", havingValue = "jwt")
     public AbstractAuthProvider jwtAuthProvider(
             ConfigurableJWTProcessor<SecurityContext> jwtProcessor,
-            AuthDataProperties authDataProperties
+            AuthDataProperties authDataProperties,
+            JwtProperties jwtProperties
     ) {
-        return new JwtAuthProvider(authDataProvider(authDataProperties), authAntPathMatcher(), jwtProcessor);
+        return new JwtAuthProvider(authDataProvider(authDataProperties), authAntPathMatcher(),
+                jwtProcessor, jwtProperties.getRolesNamespace());
     }
 
     @Bean

--- a/db2rest-auth/src/main/java/com/homihq/db2rest/auth/AuthConfiguration.java
+++ b/db2rest-auth/src/main/java/com/homihq/db2rest/auth/AuthConfiguration.java
@@ -88,7 +88,9 @@ public class AuthConfiguration {
         ConfigurableJWTProcessor<SecurityContext> jwtProcessor = new DefaultJWTProcessor<>();
 
         jwtProcessor.setJWSTypeVerifier(
-                new DefaultJOSEObjectTypeVerifier<>(new JOSEObjectType("at+jwt")));
+                new DefaultJOSEObjectTypeVerifier<>(
+                        new JOSEObjectType("at+jwt"),
+                        new JOSEObjectType("JWT")));
 
         JWSKeySelector<SecurityContext> keySelector = new JWSVerificationKeySelector<>(
                 jwtProperties.getAlgorithm(),

--- a/db2rest-auth/src/main/java/com/homihq/db2rest/auth/provider/jwt/JwtAuthProvider.java
+++ b/db2rest-auth/src/main/java/com/homihq/db2rest/auth/provider/jwt/JwtAuthProvider.java
@@ -20,11 +20,13 @@ import java.util.List;
 public class JwtAuthProvider extends AbstractAuthProvider {
     private static final String BEARER_AUTH = "Bearer";
     private final ConfigurableJWTProcessor<SecurityContext> jwtProcessor;
+    private final String rolesNamespace;
 
     public JwtAuthProvider(AuthDataLookup authDataLookup, AntPathMatcher antPathMatcher,
-                           ConfigurableJWTProcessor<SecurityContext> jwtProcessor) {
+                           ConfigurableJWTProcessor<SecurityContext> jwtProcessor, String rolesNamespace) {
         super(authDataLookup, antPathMatcher);
         this.jwtProcessor = jwtProcessor;
+        this.rolesNamespace = rolesNamespace;
     }
 
     @Override
@@ -40,7 +42,14 @@ public class JwtAuthProvider extends AbstractAuthProvider {
 
         try {
             JWTClaimsSet claimsSet = jwtProcessor.process(token, null);
-            return new UserDetail(claimsSet.getSubject(), List.of());
+            List<String> roles = List.of();
+            if (rolesNamespace != null) {
+                List<String> claimsRoles = claimsSet.getStringListClaim(rolesNamespace);
+                if (claimsRoles != null) {
+                    roles = claimsRoles;
+                }
+            }
+            return new UserDetail(claimsSet.getSubject(), roles);
         } catch (ParseException | BadJOSEException | JOSEException e) {
             log.error("Error in JWT validation - ", e);
         }

--- a/db2rest-auth/src/main/java/com/homihq/db2rest/auth/provider/jwt/JwtAuthProvider.java
+++ b/db2rest-auth/src/main/java/com/homihq/db2rest/auth/provider/jwt/JwtAuthProvider.java
@@ -64,6 +64,6 @@ public class JwtAuthProvider extends AbstractAuthProvider {
 
     @Override
     public boolean isExcluded(String requestUri, String method) {
-        return false;
+        return super.isExcludedInternal(requestUri, method, authDataLookup.getExcludedResources(), antPathMatcher);
     }
 }

--- a/db2rest-auth/src/main/java/com/homihq/db2rest/auth/provider/jwt/JwtProperties.java
+++ b/db2rest-auth/src/main/java/com/homihq/db2rest/auth/provider/jwt/JwtProperties.java
@@ -23,6 +23,7 @@ public class JwtProperties {
     private JWSAlgorithm algorithm;
     private SecretKey key;
     private String jwksUrl;
+    private String rolesNamespace;
 
     @AssertTrue(message = "Key or jwksUrl must be present!")
     public boolean isKeyOrJwksUrlPresent() {

--- a/pom.xml
+++ b/pom.xml
@@ -159,11 +159,24 @@
             <artifactId>rsql-parser</artifactId>
             <version>${rsql-parser.version}</version>
         </dependency>
-
-
-
-
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
     <profiles>
         <profile>
             <id>release</id>


### PR DESCRIPTION
DB2rest has OAuth support, but lacks a way to pass roles from the authentication server to db2rest, this PR makes this possible.
See also docs update, to properly describe this feature in the manual.